### PR TITLE
fix: get_one_connection response updated

### DIFF
--- a/ddpui/ddpairbyte/airbytehelpers.py
+++ b/ddpui/ddpairbyte/airbytehelpers.py
@@ -354,9 +354,9 @@ def get_one_connection(org: Org, connection_id: str):
 
     # fetch the source and destination names
     # the web_backend/connections/get fetches the source & destination objects also so we dont need to query again
-    source_name = airbyte_conn["source"]["sourceName"]
+    source_name = airbyte_conn["source"]["name"]
 
-    destination_name = airbyte_conn["destination"]["destinationName"]
+    destination_name = airbyte_conn["destination"]["name"]
 
     res = {
         "name": airbyte_conn["name"],

--- a/ddpui/tests/api_tests/test_airbyte_api_v1.py
+++ b/ddpui/tests/api_tests/test_airbyte_api_v1.py
@@ -86,10 +86,10 @@ def test_get_airbyte_connection_v1_without_workspace(org_without_workspace):
             "syncCatalog": "sync-catalog",
             "namespaceDefinition": "namespace-definition",
             "status": "conn-status",
-            "source": {"id": "fake-source-id-1", "sourceName": "fake-source-name-1"},
+            "source": {"id": "fake-source-id-1", "name": "fake-source-name-1"},
             "destination": {
                 "id": "fake-destination-id-1",
-                "destinationName": "fake-destination-name-1",
+                "name": "fake-destination-name-1",
             },
         }
     ),


### PR DESCRIPTION
This PR fixes #537 . The names have been updated in the  get_one_connection function to return correct response.