### PR TITLE
the filter should be on sql friendly name

### DIFF
--- a/ddpui/api/superset_api.py
+++ b/ddpui/api/superset_api.py
@@ -142,7 +142,7 @@ def post_fetch_embed_token(request, dashboard_uuid):  # pylint: disable=unused-a
                     "last_name": credentials["last_name"],
                 },
                 "resources": [{"type": "dashboard", "id": dashboard_uuid}],
-                "rls": [{"clause": f"org='{orguser.org.slug}'"}],
+                "rls": [{"clause": f"org='{orguser.org.slug.replace('-', '_')}'"}],
             },
             headers={
                 "Authorization": f"Bearer {access_token}",


### PR DESCRIPTION
For noora health, the org slug has the string `noora-health`. However for the usage pipeline, we cannot use the name `noora-health` since airbyte converts it into a sql friendly name `noora_health` while setting it as a destination schema.

So the usage pipeline is using `noora_health` while dalgo orgslug is `noora-health`. This should match for the usage dashboard to be visible. 