### PR TITLE
update invitations which don't have a new_role

### DIFF
--- a/ddpui/management/commands/role_based_access.py
+++ b/ddpui/management/commands/role_based_access.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from ddpui.models.org_user import OrgUser
+from ddpui.models.org_user import OrgUser, Invitation
 from ddpui.models.role_based_access import Role
 from ddpui.auth import ACCOUNT_MANAGER_ROLE
 
@@ -16,3 +16,6 @@ class Command(BaseCommand):
         role = Role.objects.filter(slug=ACCOUNT_MANAGER_ROLE).first()
         if role:
             OrgUser.objects.update(new_role=role)
+            Invitation.objects.filter(invited_new_role__isnull=True).update(
+                invited_new_role=role
+            )


### PR DESCRIPTION
invitations sent out before the RBAC changes don't have new_role