### PR TITLE
ability to pass target to edr commands

### DIFF
--- a/ddpui/celeryworkers/tasks.py
+++ b/ddpui/celeryworkers/tasks.py
@@ -526,18 +526,13 @@ def create_elementary_report(task_key: str, org_id: int, bucket_file_path: str):
     os.environ["PATH"] += ":" + str(Path(os.getenv("DBT_VENV")) / "venv/bin")
     cmd = [
         str(edr_binary),
-        "send-report",
+        org_task.get_task_parameters(),
         "--aws-access-key-id",
         aws_access_key_id,
         "--aws-secret-access-key",
         aws_secret_access_key,
         "--s3-bucket-name",
         s3_bucket_name,
-        # "--bucket-file-path",
-        # bucket_file_path,
-        # "--profiles-dir",
-        # str(profiles_dir),
-        org_task.get_task_parameters(),
     ]
     taskprogress.add(
         {

--- a/ddpui/celeryworkers/tasks.py
+++ b/ddpui/celeryworkers/tasks.py
@@ -521,10 +521,7 @@ def create_elementary_report(task_key: str, org_id: int, bucket_file_path: str):
         cli_options["profiles-dir"] = str(profiles_dir)
 
     if "bucket-file-path" in cli_options:
-        todays_date = datetime.today().strftime("%Y-%m-%d")
-        cli_options["bucket-file-path"] = cli_options["bucket-file-path"].replace(
-            "TODAYS_DATE", todays_date
-        )
+        cli_options["bucket-file-path"] = bucket_file_path
 
     os.environ["PATH"] += ":" + str(Path(os.getenv("DBT_VENV")) / "venv/bin")
     cmd = [

--- a/ddpui/celeryworkers/tasks.py
+++ b/ddpui/celeryworkers/tasks.py
@@ -15,6 +15,7 @@ from ddpui.utils.discord import send_discord_notification
 from ddpui.utils.sendgrid import send_email_notification, send_schema_changes_email
 from ddpui.utils.timezone import UTC, as_utc
 from ddpui.utils.custom_logger import CustomLogger
+from ddpui.core.orgtaskfunctions import get_edr_send_report_task
 from ddpui.models.org import (
     Org,
     OrgDbt,
@@ -502,11 +503,28 @@ def create_elementary_report(task_key: str, org_id: int, bucket_file_path: str):
     edr_binary = Path(os.getenv("DBT_VENV")) / "venv/bin/edr"
     org = Org.objects.filter(id=org_id).first()
     orgdbt = OrgDbt.objects.filter(org=org).first()
+    org_task = get_edr_send_report_task(org, orgdbt, create=True)
+
     project_dir = Path(orgdbt.project_dir) / "dbtrepo"
-    profiles_dir = project_dir / "elementary_profiles"
+    # profiles_dir = project_dir / "elementary_profiles"
     aws_access_key_id = os.getenv("ELEMENTARY_AWS_ACCESS_KEY_ID")
     aws_secret_access_key = os.getenv("ELEMENTARY_AWS_SECRET_ACCESS_KEY")
     s3_bucket_name = os.getenv("ELEMENTARY_S3_BUCKET")
+
+    # cli args based on the edr org task
+    cli_params = org_task.parameters
+    cli_options = cli_params.get("options", {})
+
+    # its a relative path ({"profiles-dir": "elementary_profiles", ...}) since deployment run via shell task in prefect that have a "working_dir"
+    if "profiles-dir" in cli_options:
+        profiles_dir = project_dir / cli_options["profiles-dir"]
+        cli_options["profiles-dir"] = str(profiles_dir)
+
+    if "bucket-file-path" in cli_options:
+        todays_date = datetime.today().strftime("%Y-%m-%d")
+        cli_options["bucket-file-path"] = cli_options["bucket-file-path"].replace(
+            "TODAYS_DATE", todays_date
+        )
 
     os.environ["PATH"] += ":" + str(Path(os.getenv("DBT_VENV")) / "venv/bin")
     cmd = [
@@ -518,10 +536,11 @@ def create_elementary_report(task_key: str, org_id: int, bucket_file_path: str):
         aws_secret_access_key,
         "--s3-bucket-name",
         s3_bucket_name,
-        "--bucket-file-path",
-        bucket_file_path,
-        "--profiles-dir",
-        str(profiles_dir),
+        # "--bucket-file-path",
+        # bucket_file_path,
+        # "--profiles-dir",
+        # str(profiles_dir),
+        org_task.get_task_parameters(),
     ]
     taskprogress.add(
         {

--- a/ddpui/core/orgtaskfunctions.py
+++ b/ddpui/core/orgtaskfunctions.py
@@ -85,8 +85,20 @@ def get_edr_send_report_task(org: Org, orgdbt: OrgDbt, **kwargs) -> OrgTask | No
     if task is None:
         raise ValueError("TASK_GENERATE_EDR not found")
 
+    if kwargs.get("overwrite") or kwargs.get("create"):
+        parameters = {
+            "options": {
+                "profiles-dir": "elementary_profiles",
+                "bucket-file-path": f"reports/{org.slug}.TODAYS_DATE.html",
+                "profile-target": fetch_elementary_profile_target(orgdbt),
+            }
+        }
+
     org_task = OrgTask.objects.filter(task__slug=TASK_GENERATE_EDR, org=org).first()
     if org_task:
+        if kwargs.get("overwrite"):
+            org_task.parameters = parameters
+            org_task.save()
         return org_task
 
     if kwargs.get("create"):
@@ -94,13 +106,7 @@ def get_edr_send_report_task(org: Org, orgdbt: OrgDbt, **kwargs) -> OrgTask | No
             org=org,
             task=task,
             uuid=uuid.uuid4(),
-            parameters={
-                "options": {
-                    "profiles-dir": "elementary_profiles",
-                    "bucket-file-path": f"reports/{org.slug}.TODAYS_DATE.html",
-                    "profile-target": fetch_elementary_profile_target(orgdbt),
-                }
-            },
+            parameters=parameters,
         )
     return org_task
 

--- a/ddpui/core/orgtaskfunctions.py
+++ b/ddpui/core/orgtaskfunctions.py
@@ -86,18 +86,16 @@ def get_edr_send_report_task(org: Org, orgdbt: OrgDbt, **kwargs) -> OrgTask | No
         raise ValueError("TASK_GENERATE_EDR not found")
 
     if kwargs.get("overwrite") or kwargs.get("create"):
-        parameters = {
-            "options": {
-                "profiles-dir": "elementary_profiles",
-                "bucket-file-path": f"reports/{org.slug}.TODAYS_DATE.html",
-                "profile-target": fetch_elementary_profile_target(orgdbt),
-            }
+        options = {
+            "profiles-dir": "elementary_profiles",
+            "bucket-file-path": f"reports/{org.slug}.TODAYS_DATE.html",
+            "profile-target": fetch_elementary_profile_target(orgdbt),
         }
 
     org_task = OrgTask.objects.filter(task__slug=TASK_GENERATE_EDR, org=org).first()
     if org_task:
         if kwargs.get("overwrite"):
-            org_task.parameters = parameters
+            org_task.parameters["options"] = options
             org_task.save()
         return org_task
 
@@ -106,7 +104,7 @@ def get_edr_send_report_task(org: Org, orgdbt: OrgDbt, **kwargs) -> OrgTask | No
             org=org,
             task=task,
             uuid=uuid.uuid4(),
-            parameters=parameters,
+            parameters={"options": options},
         )
     return org_task
 

--- a/ddpui/core/orgtaskfunctions.py
+++ b/ddpui/core/orgtaskfunctions.py
@@ -69,7 +69,7 @@ def fetch_elementary_profile_target(orgdbt: OrgDbt) -> str:
             config = yaml.safe_load(file)
         elementary_config = config.get("elementary", {})
         outputs = elementary_config.get("outputs", {})
-        targets = outputs.keys()
+        targets = list(outputs.keys())
         if len(targets) > 0:
             logger.info(
                 f"elementary profiles {str(targets)} found for orgdbt {orgdbt.id}. setting to the first one - {targets[0]}"
@@ -98,7 +98,7 @@ def get_edr_send_report_task(org: Org, orgdbt: OrgDbt, **kwargs) -> OrgTask | No
                 "options": {
                     "profiles-dir": "elementary_profiles",
                     "bucket-file-path": f"reports/{org.slug}.TODAYS_DATE.html",
-                    "profiles-target": fetch_elementary_profile_target(orgdbt),
+                    "profile-target": fetch_elementary_profile_target(orgdbt),
                 }
             },
         )

--- a/ddpui/core/orgtaskfunctions.py
+++ b/ddpui/core/orgtaskfunctions.py
@@ -5,8 +5,16 @@ do not raise http errors here
 
 import uuid
 from typing import Union
+import yaml
+from pathlib import Path
 from ddpui.models.tasks import OrgTask, Task, DataflowOrgTask, TaskLock, TaskLockStatus
-from ddpui.models.org import Org, OrgPrefectBlockv1, OrgDataFlowv1, TransformType
+from ddpui.models.org import (
+    Org,
+    OrgPrefectBlockv1,
+    OrgDataFlowv1,
+    TransformType,
+    OrgDbt,
+)
 from ddpui.utils.custom_logger import CustomLogger
 from ddpui.ddpprefect.schema import (
     PrefectDataFlowCreateSchema3,
@@ -44,7 +52,34 @@ def create_default_transform_tasks(
     return None, None
 
 
-def get_edr_send_report_task(org: Org, **kwargs) -> OrgTask | None:
+def fetch_elementary_profile_target(orgdbt: OrgDbt) -> str:
+    # fetch the target from the elementary profiles yaml file
+    elementary_target = "default"
+
+    # parse the yaml file
+    project_dir = Path(orgdbt.project_dir) / "dbtrepo"
+    elementary_profiles_yml = project_dir / "elementary_profiles" / "profiles.yml"
+
+    if not elementary_profiles_yml.exists():
+        logger.info(
+            f"couldn't find the profiles.yml file for the elementary setup for orgdbt {orgdbt.id}. setting target to default"
+        )
+    else:
+        with open(elementary_profiles_yml, "r") as file:
+            config = yaml.safe_load(file)
+        elementary_config = config.get("elementary", {})
+        outputs = elementary_config.get("outputs", {})
+        targets = outputs.keys()
+        if len(targets) > 0:
+            logger.info(
+                f"elementary profiles {str(targets)} found for orgdbt {orgdbt.id}. setting to the first one - {targets[0]}"
+            )
+            elementary_target = targets[0]
+
+    return elementary_target
+
+
+def get_edr_send_report_task(org: Org, orgdbt: OrgDbt, **kwargs) -> OrgTask | None:
     """creates an OrgTask for edr send-report"""
     task = Task.objects.filter(slug=TASK_GENERATE_EDR).first()
     if task is None:
@@ -63,6 +98,7 @@ def get_edr_send_report_task(org: Org, **kwargs) -> OrgTask | None:
                 "options": {
                     "profiles-dir": "elementary_profiles",
                     "bucket-file-path": f"reports/{org.slug}.TODAYS_DATE.html",
+                    "profiles-target": fetch_elementary_profile_target(orgdbt),
                 }
             },
         )

--- a/ddpui/management/commands/createedrsendreportdataflow.py
+++ b/ddpui/management/commands/createedrsendreportdataflow.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
             print(f"OrgDbt for {org.slug} not found")
             return
 
-        org_task = get_edr_send_report_task(org)
+        org_task = get_edr_send_report_task(org, org_dbt)
         if org_task is None:
             print("creating OrgTask for edr-send-report")
             org_task = get_edr_send_report_task(org, org_dbt, create=True)
@@ -88,7 +88,7 @@ class Command(BaseCommand):
             print(
                 f"creating `{options['schedule']}` OrgDataFlowv1 named {dataflow['deployment']['name']} with deployment_id {dataflow['deployment']['id']}"
             )
-            OrgDataFlowv1.objects.create(
+            dataflow = OrgDataFlowv1.objects.create(
                 org=org,
                 name=dataflow["deployment"]["name"],
                 deployment_name=dataflow["deployment"]["name"],
@@ -96,3 +96,5 @@ class Command(BaseCommand):
                 dataflow_type="manual",  # we dont want it to show in flows/pipelines page
                 cron=options["cron"] if options["schedule"] == "orchestrate" else None,
             )
+
+            DataflowOrgTask.objects.create(dataflow=dataflow, orgtask=org_task)

--- a/ddpui/management/commands/createedrsendreportdataflow.py
+++ b/ddpui/management/commands/createedrsendreportdataflow.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from django.core.management.base import BaseCommand
 
-from ddpui.models.org import Org, OrgDataFlowv1
+from ddpui.models.org import Org, OrgDataFlowv1, OrgDbt
 from ddpui.models.tasks import DataflowOrgTask
 from ddpui.core.orgtaskfunctions import get_edr_send_report_task
 from ddpui.core.pipelinefunctions import setup_edr_send_report_task_config
@@ -35,10 +35,15 @@ class Command(BaseCommand):
             print(f"Org with slug {options['org']} does not exist")
             return
 
+        org_dbt = OrgDbt.objects.filter(org=org).first()
+        if not org_dbt:
+            print(f"OrgDbt for {org.slug} not found")
+            return
+
         org_task = get_edr_send_report_task(org)
         if org_task is None:
             print("creating OrgTask for edr-send-report")
-            org_task = get_edr_send_report_task(org, create=True)
+            org_task = get_edr_send_report_task(org, org_dbt, create=True)
 
         dataflow_orgtask = DataflowOrgTask.objects.filter(orgtask=org_task).first()
 

--- a/ddpui/management/commands/updateedrsendreportdataflowtarget.py
+++ b/ddpui/management/commands/updateedrsendreportdataflowtarget.py
@@ -40,23 +40,14 @@ class Command(BaseCommand):
                 print(f"OrgDbt for {org.slug} not found")
                 return
 
-            org_task: OrgTask = get_edr_send_report_task(org, orgdbt=org_dbt)
+            org_task = get_edr_send_report_task(org, orgdbt=org_dbt, overwrite=True)
             if org_task is None:
                 print(f"edr orgtask not found {org.slug}; skipping to the next org")
                 continue
-
-            edr_target = fetch_elementary_profile_target(org_dbt)
-
-            cli_options = org_task.options() or {}
-            cli_options["profile-target"] = edr_target
-
-            # update the org_task
-            org_task.parameters = {
-                "options": cli_options,
-                **({"flags": org_task.flags() if org_task.flags() else {}}),
-            }
-            org_task.save()
-            print(f"Updated the edr org_task {org.slug} with the new elementary target")
+            else:
+                print(
+                    f"Updated the edr org_task {org.slug} with the new elementary target"
+                )
 
             dataflow_orgtask = DataflowOrgTask.objects.filter(orgtask=org_task).first()
 

--- a/ddpui/management/commands/updateedrsendreportdataflowtarget.py
+++ b/ddpui/management/commands/updateedrsendreportdataflowtarget.py
@@ -1,0 +1,103 @@
+""" create the dataflow for edr send report """
+
+from pathlib import Path
+from django.core.management.base import BaseCommand
+
+from ddpui.models.org import Org, OrgDbt
+from ddpui.models.tasks import OrgTask
+from ddpui.models.tasks import DataflowOrgTask
+from ddpui.core.orgtaskfunctions import get_edr_send_report_task
+from ddpui.core.orgtaskfunctions import fetch_elementary_profile_target
+from ddpui.core.pipelinefunctions import setup_edr_send_report_task_config
+from ddpui.core.dbtfunctions import gather_dbt_project_params
+from ddpui.ddpprefect import prefect_service
+from ddpui.ddpprefect.schema import PrefectDataFlowUpdateSchema3
+
+
+class Command(BaseCommand):
+    """Update the edr --profile-target in orgtask as well as the generate edr deployments"""
+
+    help = "Update the edr --profile-target in orgtask as well as the generate edr deployments"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--org",
+            type=str,
+            help="Org slug: use 'all' to run for all orgs at once",
+            required=True,
+        )
+
+    def handle(self, *args, **options):
+        orgs = Org.objects.all()
+        if options["org"] != "all":
+            orgs = orgs.filter(slug=options["org"])
+
+        for org in orgs:
+            print(f"running for {org.slug}")
+
+            org_dbt = OrgDbt.objects.filter(org=org).first()
+            if not org_dbt:
+                print(f"OrgDbt for {org.slug} not found")
+                return
+
+            org_task: OrgTask = get_edr_send_report_task(org, orgdbt=org_dbt)
+            if org_task is None:
+                print(f"edr orgtask not found {org.slug}; skipping to the next org")
+                continue
+
+            edr_target = fetch_elementary_profile_target(org_dbt)
+
+            cli_options = org_task.options() or {}
+            cli_options["profile-target"] = edr_target
+
+            # update the org_task
+            org_task.parameters = {
+                "options": cli_options,
+                **({"flags": org_task.flags() if org_task.flags() else {}}),
+            }
+            org_task.save()
+            print(f"Updated the edr org_task {org.slug} with the new elementary target")
+
+            dataflow_orgtask = DataflowOrgTask.objects.filter(orgtask=org_task).first()
+
+            dataflow = dataflow_orgtask.dataflow if dataflow_orgtask else None
+            if dataflow is None:
+                print(
+                    f"No generate edr dataflow found for {org.slug}; skipping to the next org"
+                )
+                continue
+
+            # update the deployment in prefect with the profile-target
+            try:
+                dbt_project_params, error = gather_dbt_project_params(org)
+                if error:
+                    print(error)
+                    return
+
+                dbt_env_dir = Path(org_dbt.dbt_venv)
+
+                task_config = setup_edr_send_report_task_config(
+                    org_task, dbt_project_params.project_dir, dbt_env_dir
+                )
+
+                prefect_service.update_dataflow_v1(
+                    dataflow.deployment_id,
+                    PrefectDataFlowUpdateSchema3(
+                        deployment_params={
+                            "config": {
+                                "tasks": [task_config.to_json()],
+                                "org_slug": org_task.org.slug,
+                            }
+                        }
+                    ),
+                )
+
+                print(
+                    f"Updated the generate edr deployment with new target ;deployment_id {dataflow.deployment_id}"
+                )
+
+            except Exception as err:
+                print(str(err))
+                print(
+                    f"Failed to update the generate edr deployment with deployment_id {dataflow.deployment_id}. Skipping to the next org"
+                )

--- a/ddpui/tests/core/test_orgtaskfunctions.py
+++ b/ddpui/tests/core/test_orgtaskfunctions.py
@@ -2,6 +2,8 @@ import os
 import django
 from django.core.management import call_command
 from django.apps import apps
+from pathlib import Path
+import yaml
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ddpui.settings")
 os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
@@ -9,9 +11,13 @@ django.setup()
 
 
 import pytest
-from ddpui.models.org import Org
-from ddpui.core.orgtaskfunctions import get_edr_send_report_task
+from ddpui.models.org import Org, OrgDbt
+from ddpui.core.orgtaskfunctions import (
+    get_edr_send_report_task,
+    fetch_elementary_profile_target,
+)
 from ddpui.models.tasks import Task
+from ddpui.tests.api_tests.test_orgtask_api import org_with_dbt_workspace
 
 pytestmark = pytest.mark.django_db
 
@@ -34,13 +40,21 @@ def test_seed_master_tasks(seed_master_tasks_db):
 # ================================================================================
 
 
-def test_get_edr_send_report_task(seed_master_tasks_db):
+def test_get_edr_send_report_task(seed_master_tasks_db, tmpdir):
     """test get_edr_send_report_task"""
 
     org = Org.objects.create(name="del", slug="del")
-    assert get_edr_send_report_task(org) is None
-    assert get_edr_send_report_task(org, create=False) is None
-    orgtask = get_edr_send_report_task(org, create=True)
+    orgdbt = OrgDbt.objects.create(
+        org=org,
+        gitrepo_url="some_repo",
+        project_dir=tmpdir,
+        target_type="postgres",
+        default_schema="staging",
+        transform_type="git",
+    )
+    assert get_edr_send_report_task(org, orgdbt) is None
+    assert get_edr_send_report_task(org, orgdbt, create=False) is None
+    orgtask = get_edr_send_report_task(org, orgdbt, create=True)
     assert orgtask is not None
     assert orgtask.org == org
     assert orgtask.task.slug == "generate-edr"
@@ -50,4 +64,54 @@ def test_get_edr_send_report_task(seed_master_tasks_db):
         orgtask.parameters["options"]["bucket-file-path"]
         == "reports/del.TODAYS_DATE.html"
     )
-    assert get_edr_send_report_task(org) is not None
+    assert orgtask.parameters["options"]["profile-target"] == "default"
+    assert get_edr_send_report_task(org, orgdbt) is not None
+
+
+def test_fetch_elementary_profile_target(tmpdir):
+    """test fetch_elementary_profile_target"""
+
+    org = Org.objects.create(name="del", slug="del")
+    orgdbt = OrgDbt.objects.create(
+        org=org,
+        gitrepo_url="some_repo",
+        project_dir=tmpdir,
+        target_type="postgres",
+        default_schema="staging",
+        transform_type="git",
+    )
+
+    project_dir = Path(orgdbt.project_dir) / "dbtrepo"
+    profiles_yml_dir = project_dir / "elementary_profiles"
+    profiles_yml_dir.mkdir(parents=True, exist_ok=True)
+
+    elementary_profiles_default = {
+        "elementary": {"outputs": {"default": {"type": "postgres", "more": "possible"}}}
+    }
+    with open(project_dir / "elementary_profiles" / "profiles.yml", "w") as file:
+        yaml.dump(elementary_profiles_default, file)
+
+    assert fetch_elementary_profile_target(orgdbt) == "default"
+
+    elementary_profiles_custom = {
+        "elementary": {"outputs": {"custom": {"type": "postgres", "more": "possible"}}}
+    }
+
+    with open(project_dir / "elementary_profiles" / "profiles.yml", "w") as file:
+        yaml.dump(elementary_profiles_custom, file)
+
+    assert fetch_elementary_profile_target(orgdbt) == "custom"
+
+    elementary_profiles_custom_multiple = {
+        "elementary": {
+            "outputs": {
+                "another": {"type": "postgres", "more": "possible"},
+                "custom": {"type": "postgres", "more": "possible"},
+            }
+        }
+    }
+
+    with open(project_dir / "elementary_profiles" / "profiles.yml", "w") as file:
+        yaml.dump(elementary_profiles_custom_multiple, file)
+
+    assert fetch_elementary_profile_target(orgdbt) == "another"


### PR DESCRIPTION
- Refactor the edr flow to make sure cli parameters are picked from `org_task.get_task_parameters()` for both celery edr generation and the send edr deployment creation . This way we only have to worry about updating the org_task and deployment if any. 
- Updated `createedrsendreportdataflow` to make sure new orgs setting up edr will have the right `--profile-target` in the deployment and org_task
- Added a new script `updateedrsendreportdataflowtarget` to update `--profile-target` for the current clients having edr org_task and deployments. 
- Add test case for the helper function that fetches target. 