### PR TITLE
getting the failure reason from the api and sending external message …

### DIFF
--- a/ddpui/ddpairbyte/airbyte_service.py
+++ b/ddpui/ddpairbyte/airbyte_service.py
@@ -399,9 +399,13 @@ def check_source_connection(workspace_id: str, data: AirbyteSourceCreate) -> dic
         },
         timeout=60,
     )
+
     if "jobInfo" not in res or res.get("status") == "failed":
-        logger.error("Failed to check source connection: %s", res)
-        raise HttpError(500, "Failed to connect - please check your crendentials")
+        failure_reason = res.get("jobInfo", {}).get("failureReason", {})
+        external_message = failure_reason.get("externalMessage", "Please check your credentials")
+        internal_message = failure_reason.get("internalMessage", "No internal message provided")
+        logger.error("Failed to check source connection: %s", internal_message)
+        raise HttpError(500, external_message)
     return res
 
 
@@ -419,8 +423,11 @@ def check_source_connection_for_update(
         timeout=60,
     )
     if "jobInfo" not in res or res.get("status") == "failed":
-        logger.error("Failed to check source connection: %s", res)
-        raise HttpError(500, "Failed to connect - please check your crendentials")
+        failure_reason = res.get("jobInfo", {}).get("failureReason", {})
+        external_message = failure_reason.get("externalMessage", "Please check your credentials")
+        internal_message = failure_reason.get("internalMessage", "No internal message provided")
+        logger.error("Failed to check source connection: %s", internal_message)
+        raise HttpError(500, external_message)
     # {
     #   'status': 'succeeded',
     #   'jobInfo': {
@@ -645,8 +652,11 @@ def check_destination_connection(
         timeout=60,
     )
     if "jobInfo" not in res or res.get("status") == "failed":
-        logger.error("Failed to check destination connection: %s", res)
-        raise HttpError(500, "Failed to connect - please check your crendentials")
+        failure_reason = res.get("jobInfo", {}).get("failureReason", {})
+        external_message = failure_reason.get("externalMessage", "Please check your credentials")
+        internal_message = failure_reason.get("internalMessage", "No internal message provided")
+        logger.error("Failed to check source connection: %s", internal_message)
+        raise HttpError(500, external_message)
     return res
 
 
@@ -667,8 +677,11 @@ def check_destination_connection_for_update(
         timeout=60,
     )
     if "jobInfo" not in res or res.get("status") == "failed":
-        logger.error("Failed to check destination connection: %s", res)
-        raise HttpError(500, "Failed to connect - please check your crendentials")
+        failure_reason = res.get("jobInfo", {}).get("failureReason", {})
+        external_message = failure_reason.get("externalMessage", "Please check your credentials")
+        internal_message = failure_reason.get("internalMessage", "No internal message provided")
+        logger.error("Failed to check source connection: %s", internal_message)
+        raise HttpError(500, external_message)
     return res
 
 

--- a/ddpui/ddpairbyte/airbyte_service.py
+++ b/ddpui/ddpairbyte/airbyte_service.py
@@ -399,13 +399,10 @@ def check_source_connection(workspace_id: str, data: AirbyteSourceCreate) -> dic
         },
         timeout=60,
     )
-
     if "jobInfo" not in res or res.get("status") == "failed":
-        failure_reason = res.get("jobInfo", {}).get("failureReason", {})
-        external_message = failure_reason.get("externalMessage", "Please check your credentials")
-        internal_message = failure_reason.get("internalMessage", "No internal message provided")
-        logger.error("Failed to check source connection: %s", internal_message)
-        raise HttpError(500, external_message)
+        failure_reason = res.get("message", "Something went wrong, please check your credentials");
+        logger.error("Failed to check the source connection: %s", res);
+        raise HttpError(500, failure_reason)
     return res
 
 
@@ -423,11 +420,9 @@ def check_source_connection_for_update(
         timeout=60,
     )
     if "jobInfo" not in res or res.get("status") == "failed":
-        failure_reason = res.get("jobInfo", {}).get("failureReason", {})
-        external_message = failure_reason.get("externalMessage", "Please check your credentials")
-        internal_message = failure_reason.get("internalMessage", "No internal message provided")
-        logger.error("Failed to check source connection: %s", internal_message)
-        raise HttpError(500, external_message)
+        failure_reason = res.get("message", "Something went wrong, please check your credentials");
+        logger.error("Failed to check the source connection: %s", res);
+        raise HttpError(500, failure_reason)
     # {
     #   'status': 'succeeded',
     #   'jobInfo': {
@@ -652,11 +647,9 @@ def check_destination_connection(
         timeout=60,
     )
     if "jobInfo" not in res or res.get("status") == "failed":
-        failure_reason = res.get("jobInfo", {}).get("failureReason", {})
-        external_message = failure_reason.get("externalMessage", "Please check your credentials")
-        internal_message = failure_reason.get("internalMessage", "No internal message provided")
-        logger.error("Failed to check source connection: %s", internal_message)
-        raise HttpError(500, external_message)
+        failure_reason = res.get("message", "Something went wrong, please check your credentials");
+        logger.error("Failed to check the destination connection: %s", res);
+        raise HttpError(500, failure_reason)
     return res
 
 
@@ -677,11 +670,9 @@ def check_destination_connection_for_update(
         timeout=60,
     )
     if "jobInfo" not in res or res.get("status") == "failed":
-        failure_reason = res.get("jobInfo", {}).get("failureReason", {})
-        external_message = failure_reason.get("externalMessage", "Please check your credentials")
-        internal_message = failure_reason.get("internalMessage", "No internal message provided")
-        logger.error("Failed to check source connection: %s", internal_message)
-        raise HttpError(500, external_message)
+        failure_reason = res.get("message", "Something went wrong, please check your credentials");
+        logger.error("Failed to check the destination connection: %s", res);
+        raise HttpError(500, failure_reason)
     return res
 
 

--- a/ddpui/ddpairbyte/airbyte_service.py
+++ b/ddpui/ddpairbyte/airbyte_service.py
@@ -400,8 +400,8 @@ def check_source_connection(workspace_id: str, data: AirbyteSourceCreate) -> dic
         timeout=60,
     )
     if "jobInfo" not in res or res.get("status") == "failed":
-        failure_reason = res.get("message", "Something went wrong, please check your credentials");
-        logger.error("Failed to check the source connection: %s", res);
+        failure_reason = res.get("message", "Something went wrong, please check your credentials")
+        logger.error("Failed to check the source connection: %s", res)
         raise HttpError(500, failure_reason)
     return res
 
@@ -420,8 +420,8 @@ def check_source_connection_for_update(
         timeout=60,
     )
     if "jobInfo" not in res or res.get("status") == "failed":
-        failure_reason = res.get("message", "Something went wrong, please check your credentials");
-        logger.error("Failed to check the source connection: %s", res);
+        failure_reason = res.get("message", "Something went wrong, please check your credentials")
+        logger.error("Failed to check the source connection: %s", res)
         raise HttpError(500, failure_reason)
     # {
     #   'status': 'succeeded',
@@ -647,8 +647,8 @@ def check_destination_connection(
         timeout=60,
     )
     if "jobInfo" not in res or res.get("status") == "failed":
-        failure_reason = res.get("message", "Something went wrong, please check your credentials");
-        logger.error("Failed to check the destination connection: %s", res);
+        failure_reason = res.get("message", "Something went wrong, please check your credentials")
+        logger.error("Failed to check the destination connection: %s", res)
         raise HttpError(500, failure_reason)
     return res
 
@@ -670,8 +670,8 @@ def check_destination_connection_for_update(
         timeout=60,
     )
     if "jobInfo" not in res or res.get("status") == "failed":
-        failure_reason = res.get("message", "Something went wrong, please check your credentials");
-        logger.error("Failed to check the destination connection: %s", res);
+        failure_reason = res.get("message", "Something went wrong, please check your credentials")
+        logger.error("Failed to check the destination connection: %s", res)
         raise HttpError(500, failure_reason)
     return res
 

--- a/ddpui/tests/services/test_airbyte_service.py
+++ b/ddpui/tests/services/test_airbyte_service.py
@@ -649,7 +649,6 @@ def test_check_source_connection_success():
         assert result == expected_response_src
         assert isinstance(result, dict)
 
-
 def test_check_source_connection_failure():
     workspace_id = "my_workspace_id"
     data = AirbyteSourceCreate(
@@ -662,11 +661,8 @@ def test_check_source_connection_failure():
         "status": "failed",
         "jobInfo": {
             "succeeded": False,
-            "failureReason": {
-                "externalMessage": "Credentials are invalid",
-                "internalMessage": "Failed to authenticate user with provided credentials. Please check the username and password."
-            }
-        }
+        },
+        "message": "Credentials are invalid"
     }
     
     with patch("ddpui.ddpairbyte.airbyte_service.abreq") as mock_abreq_:
@@ -676,6 +672,7 @@ def test_check_source_connection_failure():
             check_source_connection(workspace_id, data)
         
         assert str(excinfo.value) == "Credentials are invalid"
+
 
 
 
@@ -1162,19 +1159,19 @@ def test_check_destination_connection_failure_1():
         mock_response.headers = {"Content-Type": "application/json"}
         mock_response.json.return_value = {
             "status": "failed",
+            "message": "Credentials are invalid",
             "jobInfo": {
                 "succeeded": False,
-                "failureReason": {
-                    "externalMessage": "Credentials are invalid",
-                    "internalMessage": "Failed to authenticate user with provided credentials. Please check the username and password."
-                }
             }
         }
         mock_post.return_value = mock_response
+
         with pytest.raises(HttpError) as excinfo:
             check_destination_connection("workspace_id", payload)
 
         assert str(excinfo.value) == "Credentials are invalid"
+
+
 
 
 
@@ -1189,19 +1186,18 @@ def test_check_destination_connection_failure_2():
         mock_response.headers = {"Content-Type": "application/json"}
         mock_response.json.return_value = {
             "status": "failed",
+            "message": "Credentials are invalid",
             "jobInfo": {
                 "succeeded": False,
-                "failureReason": {
-                    "externalMessage": "Credentials are invalid",
-                    "internalMessage": "Failed to authenticate user with provided credentials. Please check the username and password."
-                }
             }
         }
         mock_post.return_value = mock_response
+
         with pytest.raises(HttpError) as excinfo:
             check_destination_connection("workspace_id", payload)
 
         assert str(excinfo.value) == "Credentials are invalid"
+
 
 
 
@@ -1233,19 +1229,18 @@ def test_check_destination_connection_for_update_failure_1():
         mock_response.headers = {"Content-Type": "application/json"}
         mock_response.json.return_value = {
             "status": "failed",
+            "message": "Credentials are invalid",
             "jobInfo": {
                 "succeeded": False,
-                "failureReason": {
-                    "externalMessage": "Credentials are invalid",
-                    "internalMessage": "Failed to authenticate user with provided credentials. Please check the username and password."
-                }
             }
         }
         mock_post.return_value = mock_response
+
         with pytest.raises(HttpError) as excinfo:
             check_destination_connection_for_update("destination_id", payload)
 
         assert str(excinfo.value) == "Credentials are invalid"
+
 
 
 
@@ -1257,19 +1252,18 @@ def test_check_destination_connection_for_update_failure_2():
         mock_response.headers = {"Content-Type": "application/json"}
         mock_response.json.return_value = {
             "status": "failed",
+            "message": "Credentials are invalid",
             "jobInfo": {
                 "succeeded": False,
-                "failureReason": {
-                    "externalMessage": "Credentials are invalid",
-                    "internalMessage": "Failed to authenticate user with provided credentials. Please check the username and password."
-                }
             }
         }
         mock_post.return_value = mock_response
+
         with pytest.raises(HttpError) as excinfo:
             check_destination_connection_for_update("destination_id", payload)
 
         assert str(excinfo.value) == "Credentials are invalid"
+
 
 
 

--- a/ddpui/tests/services/test_airbyte_service.py
+++ b/ddpui/tests/services/test_airbyte_service.py
@@ -658,14 +658,25 @@ def test_check_source_connection_failure():
         config={"key": "value"},
     )
     expected_response_srcdef = {"connectionSpecification": {"properties": {}}}
+    failed_response = {
+        "status": "failed",
+        "jobInfo": {
+            "succeeded": False,
+            "failureReason": {
+                "externalMessage": "Credentials are invalid",
+                "internalMessage": "Failed to authenticate user with provided credentials. Please check the username and password."
+            }
+        }
+    }
+    
     with patch("ddpui.ddpairbyte.airbyte_service.abreq") as mock_abreq_:
-        mock_abreq_.side_effect = [expected_response_srcdef, {}]
+        mock_abreq_.side_effect = [expected_response_srcdef, failed_response]
+        
         with pytest.raises(HttpError) as excinfo:
             check_source_connection(workspace_id, data)
-            assert (
-                str(excinfo.value)
-                == "Failed to connect - please check your crendentials"
-            )
+        
+        assert str(excinfo.value) == "Credentials are invalid"
+
 
 
 def test_check_source_connection_with_invalid_workspace_id():
@@ -1149,14 +1160,23 @@ def test_check_destination_connection_failure_1():
         mock_response = Mock(spec=requests.Response)
         mock_response.status_code = 200
         mock_response.headers = {"Content-Type": "application/json"}
-        mock_response.json.return_value = {"wrong-key": "theConnectionSpecification"}
+        mock_response.json.return_value = {
+            "status": "failed",
+            "jobInfo": {
+                "succeeded": False,
+                "failureReason": {
+                    "externalMessage": "Credentials are invalid",
+                    "internalMessage": "Failed to authenticate user with provided credentials. Please check the username and password."
+                }
+            }
+        }
         mock_post.return_value = mock_response
         with pytest.raises(HttpError) as excinfo:
             check_destination_connection("workspace_id", payload)
 
-        assert (
-            str(excinfo.value) == "Failed to connect - please check your crendentials"
-        )
+        assert str(excinfo.value) == "Credentials are invalid"
+
+
 
 
 def test_check_destination_connection_failure_2():
@@ -1167,14 +1187,22 @@ def test_check_destination_connection_failure_2():
         mock_response = Mock(spec=requests.Response)
         mock_response.status_code = 200
         mock_response.headers = {"Content-Type": "application/json"}
-        mock_response.json.return_value = {"jobInfo": {}, "status": "failed"}
+        mock_response.json.return_value = {
+            "status": "failed",
+            "jobInfo": {
+                "succeeded": False,
+                "failureReason": {
+                    "externalMessage": "Credentials are invalid",
+                    "internalMessage": "Failed to authenticate user with provided credentials. Please check the username and password."
+                }
+            }
+        }
         mock_post.return_value = mock_response
         with pytest.raises(HttpError) as excinfo:
             check_destination_connection("workspace_id", payload)
 
-        assert (
-            str(excinfo.value) == "Failed to connect - please check your crendentials"
-        )
+        assert str(excinfo.value) == "Credentials are invalid"
+
 
 
 def test_check_destination_connection_for_update_success():
@@ -1203,14 +1231,22 @@ def test_check_destination_connection_for_update_failure_1():
         mock_response = Mock(spec=requests.Response)
         mock_response.status_code = 200
         mock_response.headers = {"Content-Type": "application/json"}
-        mock_response.json.return_value = {"wrong-key": "theConnectionSpecification"}
+        mock_response.json.return_value = {
+            "status": "failed",
+            "jobInfo": {
+                "succeeded": False,
+                "failureReason": {
+                    "externalMessage": "Credentials are invalid",
+                    "internalMessage": "Failed to authenticate user with provided credentials. Please check the username and password."
+                }
+            }
+        }
         mock_post.return_value = mock_response
         with pytest.raises(HttpError) as excinfo:
             check_destination_connection_for_update("destination_id", payload)
 
-        assert (
-            str(excinfo.value) == "Failed to connect - please check your crendentials"
-        )
+        assert str(excinfo.value) == "Credentials are invalid"
+
 
 
 def test_check_destination_connection_for_update_failure_2():
@@ -1219,14 +1255,24 @@ def test_check_destination_connection_for_update_failure_2():
         mock_response = Mock(spec=requests.Response)
         mock_response.status_code = 200
         mock_response.headers = {"Content-Type": "application/json"}
-        mock_response.json.return_value = {"jobInfo": {}, "status": "failed"}
+        mock_response.json.return_value = {
+            "status": "failed",
+            "jobInfo": {
+                "succeeded": False,
+                "failureReason": {
+                    "externalMessage": "Credentials are invalid",
+                    "internalMessage": "Failed to authenticate user with provided credentials. Please check the username and password."
+                }
+            }
+        }
         mock_post.return_value = mock_response
         with pytest.raises(HttpError) as excinfo:
             check_destination_connection_for_update("destination_id", payload)
 
-        assert (
-            str(excinfo.value) == "Failed to connect - please check your crendentials"
-        )
+        assert str(excinfo.value) == "Credentials are invalid"
+
+
+
 
 
 def test_get_connections_bad_workspace_id():


### PR DESCRIPTION
-We were sending a default message of Please check credentials when the api failed.
- Now we are extracting the failure reason and sending the external_message to frontend and internal_message is for the backend logging.
- Below is the structure of the api response from airbyte docs.
{
"status": "succeeded",
"message": "string",
"jobInfo": {
"id": "191331a1-dc90-4000-8c43-c70e4df52b01",
"configType": "check_connection_source",
"configId": "string",
"createdAt": 0,
"endedAt": 0,
"succeeded": false,
"connectorConfigurationUpdated": false,
"logs": {
"logLines": [
"string"
]},
"failureReason": {
"failureOrigin": "source",
"failureType": "config_error",
**_"externalMessage": "string",
"internalMessage": "string",_**
"stacktrace": "string",
"retryable": false,
"timestamp": 0
}}}

Note: _**I could not create a real scenario where i would get the error, so i tested with a dummy res dictionary.**_