### PR TITLE
Create missing DataflowOrgtasks, remove OrgDbt parameter from get_edr_send_report_task

### DIFF
--- a/ddpui/api/orgtask_api.py
+++ b/ddpui/api/orgtask_api.py
@@ -12,7 +12,6 @@ from ninja.responses import Response
 from pydantic.error_wrappers import ValidationError as PydanticValidationError
 
 from django.forms.models import model_to_dict
-from django.db.models import Prefetch
 from ddpui import auth
 from ddpui.ddpprefect import prefect_service
 from ddpui.ddpairbyte import airbyte_service
@@ -22,6 +21,7 @@ from ddpui.ddpprefect import (
     SECRET,
 )
 from ddpui.models.org import (
+    Org,
     OrgWarehouse,
     OrgPrefectBlockv1,
 )
@@ -284,7 +284,7 @@ def post_system_transformation_tasks(request):
 @has_permission(["can_view_orgtasks"])
 def get_elemetary_task_lock(request):
     """Check if the elementary report generation task is underway"""
-    org = request.orguser.org
+    org: Org = request.orguser.org
     org_task = get_edr_send_report_task(org)
     return fetch_orgtask_lock(org_task)
 

--- a/ddpui/celeryworkers/tasks.py
+++ b/ddpui/celeryworkers/tasks.py
@@ -502,10 +502,9 @@ def create_elementary_report(task_key: str, org_id: int, bucket_file_path: str):
 
     edr_binary = Path(os.getenv("DBT_VENV")) / "venv/bin/edr"
     org = Org.objects.filter(id=org_id).first()
-    orgdbt = OrgDbt.objects.filter(org=org).first()
-    org_task = get_edr_send_report_task(org, orgdbt, create=True)
+    org_task = get_edr_send_report_task(org, create=True)
 
-    project_dir = Path(orgdbt.project_dir) / "dbtrepo"
+    project_dir = Path(org.dbt.project_dir) / "dbtrepo"
     # profiles_dir = project_dir / "elementary_profiles"
     aws_access_key_id = os.getenv("ELEMENTARY_AWS_ACCESS_KEY_ID")
     aws_secret_access_key = os.getenv("ELEMENTARY_AWS_SECRET_ACCESS_KEY")

--- a/ddpui/core/orgtaskfunctions.py
+++ b/ddpui/core/orgtaskfunctions.py
@@ -79,7 +79,7 @@ def fetch_elementary_profile_target(orgdbt: OrgDbt) -> str:
     return elementary_target
 
 
-def get_edr_send_report_task(org: Org, orgdbt: OrgDbt, **kwargs) -> OrgTask | None:
+def get_edr_send_report_task(org: Org, **kwargs) -> OrgTask | None:
     """creates an OrgTask for edr send-report"""
     task = Task.objects.filter(slug=TASK_GENERATE_EDR).first()
     if task is None:
@@ -89,7 +89,7 @@ def get_edr_send_report_task(org: Org, orgdbt: OrgDbt, **kwargs) -> OrgTask | No
         options = {
             "profiles-dir": "elementary_profiles",
             "bucket-file-path": f"reports/{org.slug}.TODAYS_DATE.html",
-            "profile-target": fetch_elementary_profile_target(orgdbt),
+            "profile-target": fetch_elementary_profile_target(org.dbt),
         }
 
     org_task = OrgTask.objects.filter(task__slug=TASK_GENERATE_EDR, org=org).first()

--- a/ddpui/management/commands/createedrsendreportdataflow.py
+++ b/ddpui/management/commands/createedrsendreportdataflow.py
@@ -87,9 +87,8 @@ class Command(BaseCommand):
 
         if options["fix_links"]:
             for org in Org.objects.exclude(dbt__isnull=True):
-                orgdbt = org.dbt
 
-                org_task = get_edr_send_report_task(org, orgdbt)
+                org_task = get_edr_send_report_task(org)
                 if org_task is None:
                     print(f"no edr OrgTask found for {org.slug}, skipping")
                     continue
@@ -119,15 +118,14 @@ class Command(BaseCommand):
             print(f"Org with slug {options['org']} does not exist")
             return
 
-        org_dbt = OrgDbt.objects.filter(org=org).first()
-        if not org_dbt:
+        if not org.dbt:
             print(f"OrgDbt for {org.slug} not found")
             return
 
-        org_task = get_edr_send_report_task(org, org_dbt)
+        org_task = get_edr_send_report_task(org)
         if org_task is None:
             print("creating OrgTask for edr-send-report")
-            org_task = get_edr_send_report_task(org, org_dbt, create=True)
+            org_task = get_edr_send_report_task(org, create=True)
 
         dataflow_orgtask = DataflowOrgTask.objects.filter(orgtask=org_task).first()
 

--- a/ddpui/management/commands/createedrsendreportdataflow.py
+++ b/ddpui/management/commands/createedrsendreportdataflow.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from django.core.management.base import BaseCommand
 
 from ddpui.models.org import Org, OrgDataFlowv1, OrgDbt
-from ddpui.models.tasks import DataflowOrgTask
+from ddpui.models.tasks import OrgTask, DataflowOrgTask
 from ddpui.core.orgtaskfunctions import get_edr_send_report_task
 from ddpui.core.pipelinefunctions import setup_edr_send_report_task_config
 from ddpui.core.dbtfunctions import gather_dbt_project_params
@@ -23,10 +23,58 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("org", type=str, help="Org slug")
-        parser.add_argument(
-            "--schedule", choices=["manual", "orchestrate"], default="manual"
-        )
         parser.add_argument("--cron", type=str, default="0 0 * * *")
+
+    def create_dataflow(self, org: Org, org_task: OrgTask, cron: str):
+        """create the DataflowOrgTask for the orgtask"""
+        print("No existing dataflow found for generate-edr, creating one")
+
+        dbt_project_params, error = gather_dbt_project_params(org)
+        if error:
+            print(error)
+            return None
+
+        dbt_env_dir = Path(org.dbt.dbt_venv)
+
+        task_config = setup_edr_send_report_task_config(
+            org_task, dbt_project_params.project_dir, dbt_env_dir
+        )
+        print("task_config for deployment")
+        print(task_config.to_json())
+
+        hash_code = generate_hash_id(8)
+        deployment_name = (
+            f"pipeline-{org_task.org.slug}-{org_task.task.slug}-{hash_code}"
+        )
+        print(f"creating deployment {deployment_name}")
+
+        dataflow = prefect_service.create_dataflow_v1(
+            PrefectDataFlowCreateSchema3(
+                deployment_name=deployment_name,
+                flow_name=deployment_name,
+                orgslug=org_task.org.slug,
+                deployment_params={
+                    "config": {
+                        "tasks": [task_config.to_json()],
+                        "org_slug": org_task.org.slug,
+                    }
+                },
+            ),
+            MANUL_DBT_WORK_QUEUE,
+        )
+
+        print(
+            f"creating OrgDataFlowv1 named {dataflow['deployment']['name']} with deployment_id {dataflow['deployment']['id']}"
+        )
+        orgdataflow = OrgDataFlowv1.objects.create(
+            org=org,
+            name=dataflow["deployment"]["name"],
+            deployment_name=dataflow["deployment"]["name"],
+            deployment_id=dataflow["deployment"]["id"],
+            dataflow_type="manual",  # we dont want it to show in flows/pipelines page
+            cron=cron,
+        )
+        return orgdataflow
 
     def handle(self, *args, **options):
 
@@ -47,54 +95,6 @@ class Command(BaseCommand):
 
         dataflow_orgtask = DataflowOrgTask.objects.filter(orgtask=org_task).first()
 
-        dataflow = dataflow_orgtask.dataflow if dataflow_orgtask else None
-        if dataflow is None:
-            print("No existing dataflow found for generate-edr, creating one")
-
-            dbt_project_params, error = gather_dbt_project_params(org)
-            if error:
-                print(error)
-                return
-
-            dbt_env_dir = Path(org.dbt.dbt_venv)
-
-            task_config = setup_edr_send_report_task_config(
-                org_task, dbt_project_params.project_dir, dbt_env_dir
-            )
-            print("task_config for deployment")
-            print(task_config.to_json())
-
-            hash_code = generate_hash_id(8)
-            deployment_name = (
-                f"pipeline-{org_task.org.slug}-{org_task.task.slug}-{hash_code}"
-            )
-            print(f"creating deployment {deployment_name}")
-
-            dataflow = prefect_service.create_dataflow_v1(
-                PrefectDataFlowCreateSchema3(
-                    deployment_name=deployment_name,
-                    flow_name=deployment_name,
-                    orgslug=org_task.org.slug,
-                    deployment_params={
-                        "config": {
-                            "tasks": [task_config.to_json()],
-                            "org_slug": org_task.org.slug,
-                        }
-                    },
-                ),
-                MANUL_DBT_WORK_QUEUE,
-            )
-
-            print(
-                f"creating `{options['schedule']}` OrgDataFlowv1 named {dataflow['deployment']['name']} with deployment_id {dataflow['deployment']['id']}"
-            )
-            data_flow = OrgDataFlowv1.objects.create(
-                org=org,
-                name=dataflow["deployment"]["name"],
-                deployment_name=dataflow["deployment"]["name"],
-                deployment_id=dataflow["deployment"]["id"],
-                dataflow_type="manual",  # we dont want it to show in flows/pipelines page
-                cron=options["cron"] if options["schedule"] == "orchestrate" else None,
-            )
-
-            DataflowOrgTask.objects.create(dataflow=data_flow, orgtask=org_task)
+        if dataflow_orgtask is None:
+            dataflow = self.create_dataflow(org, org_task, options["cron"])
+            DataflowOrgTask.objects.create(dataflow=dataflow, orgtask=org_task)

--- a/ddpui/management/commands/updateedrsendreportdataflowtarget.py
+++ b/ddpui/management/commands/updateedrsendreportdataflowtarget.py
@@ -35,12 +35,11 @@ class Command(BaseCommand):
         for org in orgs:
             print(f"running for {org.slug}")
 
-            org_dbt = OrgDbt.objects.filter(org=org).first()
-            if not org_dbt:
+            if not org.dbt:
                 print(f"OrgDbt for {org.slug} not found")
                 continue
 
-            org_task = get_edr_send_report_task(org, orgdbt=org_dbt, overwrite=True)
+            org_task = get_edr_send_report_task(org, overwrite=True)
             if org_task is None:
                 print(f"edr orgtask not found {org.slug}; skipping to the next org")
                 continue
@@ -65,7 +64,7 @@ class Command(BaseCommand):
                     print(error)
                     continue
 
-                dbt_env_dir = Path(org_dbt.dbt_venv)
+                dbt_env_dir = Path(org.dbt.dbt_venv)
 
                 task_config = setup_edr_send_report_task_config(
                     org_task, dbt_project_params.project_dir, dbt_env_dir

--- a/ddpui/tests/core/test_orgtaskfunctions.py
+++ b/ddpui/tests/core/test_orgtaskfunctions.py
@@ -52,9 +52,10 @@ def test_get_edr_send_report_task(seed_master_tasks_db, tmpdir):
         default_schema="staging",
         transform_type="git",
     )
-    assert get_edr_send_report_task(org, orgdbt) is None
-    assert get_edr_send_report_task(org, orgdbt, create=False) is None
-    orgtask = get_edr_send_report_task(org, orgdbt, create=True)
+    org.dbt = orgdbt
+    assert get_edr_send_report_task(org) is None
+    assert get_edr_send_report_task(org, create=False) is None
+    orgtask = get_edr_send_report_task(org, create=True)
     assert orgtask is not None
     assert orgtask.org == org
     assert orgtask.task.slug == "generate-edr"
@@ -65,7 +66,7 @@ def test_get_edr_send_report_task(seed_master_tasks_db, tmpdir):
         == "reports/del.TODAYS_DATE.html"
     )
     assert orgtask.parameters["options"]["profile-target"] == "default"
-    assert get_edr_send_report_task(org, orgdbt) is not None
+    assert get_edr_send_report_task(org) is not None
 
 
 def test_fetch_elementary_profile_target(tmpdir):


### PR DESCRIPTION
Linking objects between the `edr` `OrgTasks` and the prefect deployments `OrgDataFlowv1` were missing. This script fixed that

Also noticed that `get_edr_send_report` doesn't need the `OrgDbt` parameter, since `org.dbt` exists. Removed it