### PR TITLE
Created task and added to redis so that we are able to fetch the task immediately on polling

### DIFF
--- a/ddpui/api/airbyte_api.py
+++ b/ddpui/api/airbyte_api.py
@@ -674,6 +674,11 @@ def get_connection_catalog_v1(request, connection_id):
             ]:
                 return {"task_id": task_key, "message": "already running"}
 
+    taskprogress = SingleTaskProgress(
+        task_key, int(os.getenv("SCHEMA_REFRESH_TTL", "180"))
+    )
+
+    taskprogress.add({"message": "queued", "status": "queued", "result": None})
     # ignore the returned celery task id
     get_connection_catalog_task.delay(task_key, orguser.org.id, connection_id)
 


### PR DESCRIPTION
Created task and added to redis so that we are able to fetch the task immediately on polling.
One of the fixes for https://github.com/DalgoT4D/webapp/issues/1052