### PR TITLE
Remove deprecated function and task_lock

### DIFF
--- a/ddpui/api/orgtask_api.py
+++ b/ddpui/api/orgtask_api.py
@@ -417,9 +417,7 @@ def post_run_prefect_org_task(request, orgtask_uuid, payload: TaskParameters = N
     if orguser.org.dbt is None:
         raise HttpError(400, "dbt is not configured for this client")
 
-    # release the lock
-    task_lock.delete()
-    logger.info("released lock on task %s", org_task.task.slug)
+
     # If you want the function to do nothing else, you can return None here
     return None
 


### PR DESCRIPTION
This pull request removes a deprecated function and the task_lock feature. The deprecated function was causing issues and is no longer needed, so it has been removed. The task_lock feature was causing conflicts and is no longer necessary, so it has been removed as well.