### PR TITLE
Incorrect order of dbt tasks

### DIFF
--- a/ddpui/api/orgtask_api.py
+++ b/ddpui/api/orgtask_api.py
@@ -50,11 +50,11 @@ from ddpui.utils import secretsmanager
 from ddpui.utils import timezone
 from ddpui.utils.helpers import map_airbyte_keys_to_postgres_keys
 from ddpui.utils.constants import (
-    TASK_DBTRUN,
     TASK_GITPULL,
     TRANSFORM_TASKS_SEQ,
     TASK_GENERATE_EDR,
-    TASK_SEED,
+    LONG_RUNNING_TASKS,
+    DEFAULT_TRANSFORM_TASKS_IN_PIPELINE,
 )
 from ddpui.core.orgtaskfunctions import get_edr_send_report_task
 from ddpui.core.pipelinefunctions import (
@@ -133,7 +133,7 @@ def post_orgtask(request, payload: CreateOrgTaskPayload):
     )
 
     dataflow = None
-    if task.slug in [TASK_DBTRUN, TASK_SEED]:
+    if task.slug in LONG_RUNNING_TASKS:
         dbt_project_params, error = gather_dbt_project_params(orguser.org)
         if error:
             raise HttpError(400, error)
@@ -165,13 +165,12 @@ def post_system_transformation_tasks(request):
     """
     - Create a git pull url secret block
     - Create a dbt cli profile block
-    - Create dbt tasks
+    - Create all the system transform tasks
         - git pull
         - dbt deps
         - dbt clean
         - dbt run
         - dbt test
-        - dbt docs generate
     """
     orguser: OrgUser = request.orguser
     if orguser.org.dbt is None:
@@ -336,6 +335,8 @@ def get_prefect_transformation_tasks(request):
                 "command": command,
                 "generated_by": org_task.generated_by,
                 "seq": TRANSFORM_TASKS_SEQ[org_task.task.slug],
+                "pipeline_default": org_task.task.slug
+                in DEFAULT_TRANSFORM_TASKS_IN_PIPELINE,
             }
         )
 

--- a/ddpui/api/orgtask_api.py
+++ b/ddpui/api/orgtask_api.py
@@ -350,7 +350,7 @@ def get_prefect_transformation_tasks(request):
             else None
         )
 
-    return res
+    return sorted(res, key=lambda x: x["seq"])
 
 
 @orgtaskapi.delete("transform/", auth=auth.CustomAuthMiddleware())

--- a/ddpui/core/orgtaskfunctions.py
+++ b/ddpui/core/orgtaskfunctions.py
@@ -23,7 +23,10 @@ from ddpui.ddpprefect import MANUL_DBT_WORK_QUEUE
 from ddpui.ddpdbt.schema import DbtProjectParams
 from ddpui.ddpprefect import prefect_service
 from ddpui.core.pipelinefunctions import setup_dbt_core_task_config
-from ddpui.utils.constants import TASK_DBTRUN, TASK_GENERATE_EDR
+from ddpui.utils.constants import (
+    TASK_DBTRUN,
+    TASK_GENERATE_EDR,
+)
 from ddpui.utils.helpers import generate_hash_id
 
 logger = CustomLogger("ddpui")

--- a/ddpui/core/orgtaskfunctions.py
+++ b/ddpui/core/orgtaskfunctions.py
@@ -23,10 +23,7 @@ from ddpui.ddpprefect import MANUL_DBT_WORK_QUEUE
 from ddpui.ddpdbt.schema import DbtProjectParams
 from ddpui.ddpprefect import prefect_service
 from ddpui.core.pipelinefunctions import setup_dbt_core_task_config
-from ddpui.utils.constants import (
-    TASK_DBTRUN,
-    TASK_GENERATE_EDR,
-)
+from ddpui.utils.constants import TASK_DBTRUN, TASK_GENERATE_EDR, TRANSFORM_TASKS_SEQ
 from ddpui.utils.helpers import generate_hash_id
 
 logger = CustomLogger("ddpui")

--- a/ddpui/ddpdbt/dbt_service.py
+++ b/ddpui/ddpdbt/dbt_service.py
@@ -24,6 +24,13 @@ from ddpui.models.org_user import Org
 from ddpui.models.tasks import Task, OrgTask, DataflowOrgTask
 from ddpui.models.dbt_workflow import OrgDbtModel
 from ddpui.utils import secretsmanager
+from ddpui.utils.constants import (
+    TASK_DOCSGENERATE,
+    TASK_DBTTEST,
+    TASK_DBTRUN,
+    TASK_DBTSEED,
+    TASK_DBTDEPS,
+)
 from ddpui.utils.timezone import as_ist
 from ddpui.utils.custom_logger import CustomLogger
 from ddpui.utils.singletaskprogress import SingleTaskProgress
@@ -102,10 +109,11 @@ def task_config_params(task: Task):
 
     # dbt task config parameters
     TASK_CONIF_PARAM = {
-        "dbt-deps": {"flags": ["upgrade"], "options": ["add-package"]},
-        "dbt-run": {"flags": ["full-refresh"], "options": ["select", "exclude"]},
-        "dbt-test": {"flags": [], "options": ["select", "exclude"]},
-        "dbt-seed": {"flags": [], "options": ["select"]},
+        TASK_DBTDEPS: {"flags": ["upgrade"], "options": ["add-package"]},
+        TASK_DBTRUN: {"flags": ["full-refresh"], "options": ["select", "exclude"]},
+        TASK_DBTTEST: {"flags": [], "options": ["select", "exclude"]},
+        TASK_DBTSEED: {"flags": [], "options": ["select"]},
+        TASK_DOCSGENERATE: {"flags": [], "options": []},
     }
 
     return TASK_CONIF_PARAM[task.slug] if task.slug in TASK_CONIF_PARAM else None

--- a/ddpui/management/commands/manage-transform-tasks.py
+++ b/ddpui/management/commands/manage-transform-tasks.py
@@ -1,0 +1,126 @@
+from dotenv import load_dotenv
+from django.core.management.base import BaseCommand
+
+from django.contrib.auth.models import User
+from ddpui.utils.custom_logger import CustomLogger
+from ddpui.models.tasks import OrgTask, Task, OrgTaskGeneratedBy, DataflowOrgTask
+from ddpui.models.org import Org, OrgDataFlowv1
+from ddpui.utils.constants import TASK_DBTSEED, TASK_DOCSGENERATE
+from ddpui.ddpprefect import prefect_service
+from ddpui.ddpprefect.schema import PrefectDataFlowUpdateSchema3
+
+logger = CustomLogger("ddpui")
+
+load_dotenv()
+
+
+class Command(BaseCommand):
+    """
+    This script manages the transform tasks
+    """
+
+    help = "This script manages the transform tasks"
+
+    def add_dbt_seed_as_transform_task(self, org: Org):
+        """
+        Add dbt seed as a transform task
+        1. Check if the org has dbt-seed task added or not. If not, create it as a system task
+        2. If the task is there and has `generated_by` = client, make it as system task i.e. `generated_by` = system
+        """
+        assert Task.objects.filter(
+            slug=TASK_DBTSEED
+        ).exists(), "dbt-seed task not found"
+        assert Task.objects.filter(
+            slug=TASK_DBTSEED, is_system=True
+        ).exists(), "dbt-seed task is not a system task. please make sure to run the seeder at seed/tasks.json"
+
+        org_task = OrgTask.objects.filter(org=org, task__slug=TASK_DBTSEED).first()
+
+        if not org_task:
+            OrgTask.objects.create(
+                org=org,
+                task=Task.objects.filter(slug=TASK_DBTSEED).first(),
+                generated_by=OrgTaskGeneratedBy.SYSTEM,
+            )
+            logger.info(
+                f"Added system {TASK_DBTSEED} task as a transform task for org {org.slug}"
+            )
+        else:
+            if org_task.generated_by == OrgTaskGeneratedBy.CLIENT:
+                org_task.generated_by = OrgTaskGeneratedBy.SYSTEM
+                org_task.save()
+                logger.info(
+                    f"Changed {TASK_DBTSEED} task to system task for org {org.slug}"
+                )
+
+        return None
+
+    def remove_dbt_docs_generate_from_current_pipelines(self, org: Org):
+        """
+        1. Update the deployment params in prefect to remove this task
+        2. Remove the orgtask mapping in DataflowOrgTask
+        """
+        for dataflow in OrgDataFlowv1.objects.filter(
+            org=org, dataflow_type="orchestrate"
+        ).all():
+            deployment_id = dataflow.deployment_id
+            try:
+                deployment = prefect_service.get_deployment(deployment_id)
+            except Exception as err:
+                logger.error(
+                    f"Error while fetching deployment params for deployment_id {dataflow.deployment_id} {org.slug}: {err}"
+                )
+                continue
+
+            params = deployment.get("parameters", {})
+            config = params.get("config", {})
+            tasks = config.get("tasks", [])
+
+            if len(tasks) > 0:
+                updated_task_list = [
+                    task for task in tasks if task["slug"] != TASK_DOCSGENERATE
+                ]
+                tasks = updated_task_list
+
+                try:
+                    prefect_service.update_dataflow_v1(
+                        dataflow.deployment_id,
+                        PrefectDataFlowUpdateSchema3(
+                            deployment_params={"config": config}
+                        ),
+                    )
+                except Exception as err:
+                    logger.error(
+                        f"Error while updating deployment params for deployment_id {dataflow.deployment_id} {org.slug}: {err}"
+                    )
+                    continue
+
+            # remove the DataflowOrgTask mapping
+            DataflowOrgTask.objects.filter(
+                dataflow=dataflow, orgtask__task__slug=TASK_DOCSGENERATE
+            ).delete()
+
+            logger.info(
+                f"Removed dbt-docs-generate task from orchestrate pipeline for deployment {dataflow.deployment_id} {org.slug}"
+            )
+
+        ## assert if any mapping it still there
+        assert (
+            DataflowOrgTask.objects.filter(
+                orgtask__task__slug=TASK_DOCSGENERATE,
+                dataflow__dataflow_type="orchestrate",
+            ).count()
+            == 0
+        ), "Some mappings still exist for dbt-docs-generate task"
+
+        logger.info("Validated")
+
+        return None
+
+    def add_arguments(self, parser):  # skipcq: PYL-R0201
+        pass
+
+    def handle(self, *args, **options):
+        for org in Org.objects.all():
+            self.add_dbt_seed_as_transform_task(org)
+            self.remove_dbt_docs_generate_from_current_pipelines(org)

--- a/ddpui/management/commands/sync-the-pipeline-transform-tasks-seq.py
+++ b/ddpui/management/commands/sync-the-pipeline-transform-tasks-seq.py
@@ -1,0 +1,106 @@
+from dotenv import load_dotenv
+from django.core.management.base import BaseCommand
+
+from django.contrib.auth.models import User
+from ddpui.utils.custom_logger import CustomLogger
+from ddpui.models.tasks import OrgTask, Task, OrgTaskGeneratedBy, DataflowOrgTask
+from ddpui.models.org import Org, OrgDataFlowv1
+from ddpui.utils.constants import TASK_DBTSEED, TASK_DOCSGENERATE, TRANSFORM_TASKS_SEQ
+from ddpui.ddpprefect import prefect_service
+from ddpui.ddpprefect.schema import PrefectDataFlowUpdateSchema3
+from ddpui.core.pipelinefunctions import fix_transform_tasks_seq_dataflow
+
+logger = CustomLogger("ddpui")
+
+load_dotenv()
+
+
+class Command(BaseCommand):
+    """
+    Make sures the seq of transform tasks in a pipeline is correct
+    """
+
+    help = "Make sures the seq of transform tasks in a pipeline is correct"
+
+    def add_arguments(self, parser):  # skipcq: PYL-R0201
+        parser.add_argument(
+            "--org",
+            type=str,
+            help="Org slug: use 'all' to run for all orgs at once",
+            required=False,
+        )
+        parser.add_argument(
+            "--deployment_id",
+            type=str,
+            help="deployment id of the pipeline",
+            required=False,
+        )
+        parser.add_argument(
+            "--fix",
+            action="store_true",
+            help="Fix the seq of transform tasks",
+            required=False,
+        )
+
+    def handle(self, *args, **options):
+        """
+        1. Fetch all the dataflows to be checked based on the arguments passed
+        2. For each dataflow, fetch deployment params and check the seq of transform tasks
+        3. If the seq is incorrect, push it to an array
+        4. Print/log all the incorrect deployment & their org slugs
+        5. If argument to fix is passed, fix the seq of transform tasks
+        """
+
+        org_slug = options["org"]
+        deployment_id = options["deployment_id"]
+        query = OrgDataFlowv1.objects
+
+        if org_slug:
+            query = query.filter(org__slug=org_slug)
+
+        if deployment_id:
+            query = query.filter(deployment_id=deployment_id)
+
+        deployments_to_fix = []
+
+        for dataflow in query.all():
+            try:
+                deployment = prefect_service.get_deployment(dataflow.deployment_id)
+            except Exception as e:
+                logger.error(
+                    f"Error getting deployment for {dataflow.deployment_id} | {dataflow.org.slug}: {str(e)}"
+                )
+                continue
+
+            params = deployment.get("parameters", {})
+            config = params.get("config", {})
+            tasks = config.get("tasks", [])
+            transform_tasks = [
+                task for task in tasks if task["slug"] in TRANSFORM_TASKS_SEQ
+            ]
+
+            if len(transform_tasks) <= 1:
+                logger.info(
+                    f"Skipping, found only {len(tasks)} transform tasks for {dataflow.deployment_id} | {dataflow.org.slug}"
+                )
+                continue
+
+            is_seq_correct = True  # assume its correctly sorted in ascending order
+            transform_task_slugs = [
+                task["slug"] for task in sorted(transform_tasks, key=lambda x: x["seq"])
+            ]
+            order = [TRANSFORM_TASKS_SEQ[slug] for slug in transform_task_slugs]
+            for i in range(1, len(order)):
+                if order[i] < order[i - 1]:
+                    is_seq_correct = False
+                    break
+
+            if not is_seq_correct:
+                deployments_to_fix.append(dataflow.deployment_id)
+
+        logger.info(f"Found {len(deployments_to_fix)} deployments to fix")
+        logger.info(deployments_to_fix)
+
+        if options["fix"] and len(deployments_to_fix) > 0:
+            for deployment_id in deployments_to_fix:
+                fix_transform_tasks_seq_dataflow(deployment_id)

--- a/ddpui/management/commands/sync-the-pipeline-transform-tasks-seq.py
+++ b/ddpui/management/commands/sync-the-pipeline-transform-tasks-seq.py
@@ -1,13 +1,10 @@
 from dotenv import load_dotenv
 from django.core.management.base import BaseCommand
 
-from django.contrib.auth.models import User
 from ddpui.utils.custom_logger import CustomLogger
-from ddpui.models.tasks import OrgTask, Task, OrgTaskGeneratedBy, DataflowOrgTask
-from ddpui.models.org import Org, OrgDataFlowv1
-from ddpui.utils.constants import TASK_DBTSEED, TASK_DOCSGENERATE, TRANSFORM_TASKS_SEQ
+from ddpui.models.org import OrgDataFlowv1
+from ddpui.utils.constants import TRANSFORM_TASKS_SEQ
 from ddpui.ddpprefect import prefect_service
-from ddpui.ddpprefect.schema import PrefectDataFlowUpdateSchema3
 from ddpui.core.pipelinefunctions import fix_transform_tasks_seq_dataflow
 
 logger = CustomLogger("ddpui")

--- a/ddpui/utils/constants.py
+++ b/ddpui/utils/constants.py
@@ -7,7 +7,7 @@ TASK_GITPULL = "git-pull"
 TASK_DOCSGENERATE = "dbt-docs-generate"
 TASK_AIRBYTESYNC = "airbyte-sync"
 TASK_AIRBYTERESET = "airbyte-reset"
-TASK_SEED = "dbt-seed"
+TASK_DBTSEED = "dbt-seed"
 TASK_GENERATE_EDR = "generate-edr"
 UPDATE_SCHEMA = "update-schema"
 
@@ -19,9 +19,22 @@ TRANSFORM_TASKS_SEQ = {
     TASK_DBTRUN: 4,
     TASK_DBTTEST: 5,
     TASK_DOCSGENERATE: 6,
-    TASK_SEED: 0,
+    TASK_DBTSEED: 0,
     TASK_GENERATE_EDR: 7,
 }
+# when a new pipeline is created; these are the transform tasks being pushed by default
+DEFAULT_TRANSFORM_TASKS_IN_PIPELINE = [
+    TASK_GITPULL,
+    TASK_DBTCLEAN,
+    TASK_DBTDEPS,
+    TASK_DBTRUN,
+    TASK_DBTTEST,
+]
+
+# These are tasks to be run via deployment
+# Adding a new task here will work for any new orgtask created
+# But for the current ones a script would need to be run to set them with a deployment
+LONG_RUNNING_TASKS = [TASK_DBTRUN, TASK_DBTSEED, TASK_DBTTEST]
 
 # airbyte sync timeout in deployment params
 AIRBYTE_SYNC_TIMEOUT = 15

--- a/ddpui/utils/constants.py
+++ b/ddpui/utils/constants.py
@@ -16,11 +16,11 @@ TRANSFORM_TASKS_SEQ = {
     TASK_GITPULL: 1,
     TASK_DBTCLEAN: 2,
     TASK_DBTDEPS: 3,
-    TASK_DBTRUN: 4,
-    TASK_DBTTEST: 5,
-    TASK_DOCSGENERATE: 6,
-    TASK_DBTSEED: 0,
-    TASK_GENERATE_EDR: 7,
+    TASK_DBTSEED: 4,
+    TASK_DBTRUN: 5,
+    TASK_DBTTEST: 6,
+    TASK_DOCSGENERATE: 7,
+    TASK_GENERATE_EDR: 8,
 }
 # when a new pipeline is created; these are the transform tasks being pushed by default
 DEFAULT_TRANSFORM_TASKS_IN_PIPELINE = [

--- a/seed/tasks.json
+++ b/seed/tasks.json
@@ -84,7 +84,7 @@
             "slug": "dbt-seed",
             "label": "DBT seed",
             "command": "seed",
-            "is_system": false
+            "is_system": true
         }
     },
     {


### PR DESCRIPTION
This PR does the following
- Addes `dbt seed` as a system generated task
- Removes `dbt docs generate` from current and future dataflows/pipelines
- Removes `dbt docs generate` from being used as the default task while adding a pipeline using `simple` strategy
- A script to find out if the deployment seq is messed up or not. If it is, pass `--fix` to fix it. The seq is checked based on the seq defined `ddpui/utils/constants.py TRANSFORM_TASKS_SEQ`. This is only for transform tasks. 
- Allow `dbt docs generate` to be added as a custom task.
- Corresponding webapp PR - https://github.com/DalgoT4D/webapp/pull/1158 


The original issue is not reproducible. 