### PR TITLE
production webhook failure fix - sentry

### DIFF
--- a/ddpui/api/pipeline_api.py
+++ b/ddpui/api/pipeline_api.py
@@ -649,11 +649,13 @@ def post_run_prefect_org_deployment_task(
 @pipelineapi.get("flow_runs/{flow_run_id}/logs", auth=auth.CustomAuthMiddleware())
 @has_permission(["can_view_pipeline"])
 def get_flow_runs_logs(
-    request, flow_run_id, task_run_id = '', limit: int = 0, offset: int = 0
+    request, flow_run_id, task_run_id="", limit: int = 0, offset: int = 0
 ):  # pylint: disable=unused-argument
     """return the logs from a flow-run"""
     try:
-        result = prefect_service.get_flow_run_logs(flow_run_id, task_run_id,limit,offset)
+        result = prefect_service.get_flow_run_logs(
+            flow_run_id, task_run_id, limit, offset
+        )
     except Exception as error:
         logger.exception(error)
         raise HttpError(400, "failed to retrieve logs") from error
@@ -711,10 +713,7 @@ def get_prefect_flow_runs_log_history(
 
     if fetchlogs:
         for flow_run in flow_runs:
-            logs_dict = prefect_service.get_flow_run_logs(flow_run["id"], 0)
-            flow_run["logs"] = (
-                logs_dict["logs"]["logs"] if "logs" in logs_dict["logs"] else []
-            )
+            flow_run["logs"] = prefect_service.recurse_flow_run_logs(flow_run["id"], None)
 
     return flow_runs
 

--- a/ddpui/management/commands/saveflowrunlogstos3.py
+++ b/ddpui/management/commands/saveflowrunlogstos3.py
@@ -29,14 +29,13 @@ class Command(BaseCommand):
             )
             for flow_run in flow_runs:
                 flow_run_id = flow_run["id"]
-                logs_dict = prefect_service.get_flow_run_logs(flow_run_id, 0)
-                if "logs" in logs_dict["logs"]:
-                    flow_run_logs = logs_dict["logs"]["logs"]
+                logs_arr = prefect_service.recurse_flow_run_logs(flow_run_id)
+                if len(logs_arr) > 0:
                     s3key = f"logs/prefect/{org}/{flow_run_id}.json"
                     s3.put_object(
                         Bucket="dalgo-t4dai",
                         Key=s3key,
-                        Body=json.dumps(flow_run_logs),
+                        Body=json.dumps(logs_arr),
                     )
                     print(f"Saved s3://dalgo-t4dai/{s3key}")
 

--- a/ddpui/utils/webhook_helpers.py
+++ b/ddpui/utils/webhook_helpers.py
@@ -114,7 +114,7 @@ def email_orgusers_ses_whitelisted(org: Org, email_body: str):
 
 def email_flowrun_logs_to_orgusers(org: Org, flow_run_id: str):
     """retrieves logs for a flow-run and emails them to all users for the org"""
-    logs = prefect_service.get_flow_run_logs(flow_run_id, 0)
-    logmessages = [x["message"] for x in logs["logs"]["logs"]]
+    logs_arr = prefect_service.recurse_flow_run_logs(flow_run_id)
+    logmessages = [x["message"] for x in logs_arr]
     email_body = generate_notification_email(org.name, flow_run_id, logmessages)
     email_orgusers(org, email_body)


### PR DESCRIPTION
@fatchat the production sentry bug was in the webhook where it was fetching logs for a failed run. Since we (huzaif's logs pagination PR) updated the flow run logs api , we forgot to change things here. 