### PR TITLE
Bug/duplicate model name

### DIFF
--- a/ddpui/api/transform_api.py
+++ b/ddpui/api/transform_api.py
@@ -364,6 +364,18 @@ def post_save_model(request, model_uuid: str, payload: CompleteDbtModelPayload):
     if not orgdbt_model:
         raise HttpError(404, "model not found")
 
+    # prevent duplicate models
+    if (
+        OrgDbtModel.objects.filter(orgdbt=orgdbt, name=payload.name)
+        .exclude(uuid=orgdbt_model.uuid)
+        .exists()
+    ):
+        raise HttpError(422, "model with this name already exists")
+
+    # when you are overwriting the existing model with same name but different schema; which again leads to duplicate models
+    if payload.name == orgdbt_model.name and payload.dest_schema != orgdbt_model.schema:
+        raise HttpError(422, "model with this name already exists in the schema")
+
     check_canvas_locked(orguser, payload.canvas_lock_id)
 
     payload.name = slugify(payload.name)

--- a/ddpui/api/transform_api.py
+++ b/ddpui/api/transform_api.py
@@ -373,7 +373,11 @@ def post_save_model(request, model_uuid: str, payload: CompleteDbtModelPayload):
         raise HttpError(422, "model with this name already exists")
 
     # when you are overwriting the existing model with same name but different schema; which again leads to duplicate models
-    if payload.name == orgdbt_model.name and payload.dest_schema != orgdbt_model.schema:
+    if (
+        payload.name == orgdbt_model.name
+        and payload.dest_schema != orgdbt_model.schema
+        and not orgdbt_model.under_construction
+    ):
         raise HttpError(422, "model with this name already exists in the schema")
 
     check_canvas_locked(orguser, payload.canvas_lock_id)


### PR DESCRIPTION
Fixes https://github.com/DalgoT4D/webapp/issues/1247

Webapp- https://github.com/DalgoT4D/webapp/pull/1250


Dbt model names need to be unique. Fix handles these cases
- When the model is materialized and we go & edit an operation to re-save the model. This action should not allow them to create a model with same name but different schema. 
- When there is  a separate chain but you try to save the model with the same name (any schema, deosn't matter). This action should not be allowed