### PR TITLE
Notifications tweaks

### DIFF
--- a/ddpui/api/webhook_api.py
+++ b/ddpui/api/webhook_api.py
@@ -134,7 +134,7 @@ def post_notification_v1(request):  # pylint: disable=unused-argument
             notify_platform_admins(org, flow_run["id"], state)
             notify_org_managers(
                 org,
-                f"A job for \"{name_of_deployment}\" of type \"{type_of_deployment}\" has failed, please visit {os.getenv('FRONTEND_URL')} for more details",
+                f"To the admins of {org.name},\n\nA job for \"{name_of_deployment}\" of type \"{type_of_deployment}\" has failed, please visit {os.getenv('FRONTEND_URL')} for more details",
             )
             email_orgusers_ses_whitelisted(
                 org,

--- a/ddpui/celeryworkers/tasks.py
+++ b/ddpui/celeryworkers/tasks.py
@@ -453,9 +453,13 @@ def detect_schema_changes_for_org(org: Org):
         # notify users
         if change_type in ["breaking", "non_breaking"]:
             try:
+                frontend_url = os.getenv("FRONTEND_URL")
+                if frontend_url.endswith("/"):
+                    frontend_url = frontend_url[:-1]
+                connections_page = f"{frontend_url}/pipeline/ingest?tab=connections"
                 notify_org_managers(
                     org,
-                    "This email is to let you know that schema changes have been detected in your Dalgo pipeline, which require your review.",
+                    f"To the admins of {org.name},\n\nThis email is to let you know that schema changes have been detected in your Dalgo pipeline.\n\nPlease visit {connections_page} and review the Pending Actions",
                 )
             except Exception as err:
                 logger.error(err)

--- a/ddpui/celeryworkers/tasks.py
+++ b/ddpui/celeryworkers/tasks.py
@@ -459,7 +459,9 @@ def detect_schema_changes_for_org(org: Org):
                 connections_page = f"{frontend_url}/pipeline/ingest?tab=connections"
                 notify_org_managers(
                     org,
-                    f"To the admins of {org.name},\n\nThis email is to let you know that schema changes have been detected in your Dalgo pipeline.\n\nPlease visit {connections_page} and review the Pending Actions",
+                    f"To the admins of {org.name},\n\nThis email is to let you know that"
+                    " schema changes have been detected in your Dalgo sources.\n\nPlease"
+                    f" visit {connections_page} and review the Pending Actions",
                 )
             except Exception as err:
                 logger.error(err)

--- a/ddpui/core/notifications_service.py
+++ b/ddpui/core/notifications_service.py
@@ -12,7 +12,7 @@ from ddpui.models.org_user import OrgUser
 from ddpui.models.org_preferences import OrgPreferences
 from ddpui.utils import timezone
 from ddpui.utils.discord import send_discord_notification
-from ddpui.utils.sendgrid import send_email_notification
+from ddpui.utils.awsses import send_text_message
 from ddpui.schemas.notifications_api_schemas import SentToEnum, NotificationDataSchema
 from ddpui.celeryworkers.moretasks import schedule_notification_task
 
@@ -83,7 +83,9 @@ def handle_recipient(
 
         if user_preference.enable_email_notifications:
             try:
-                send_email_notification(user_preference.orguser.user.email, notification.message)
+                send_text_message(
+                    user_preference.orguser.user.email, "Message from Dalgo", notification.message
+                )
             except Exception as e:
                 return {
                     "recipient": notification_recipient.recipient.user.email,

--- a/ddpui/tests/core/test_celery_tasks.py
+++ b/ddpui/tests/core/test_celery_tasks.py
@@ -398,7 +398,7 @@ def test_detect_schema_changes_for_org_send_schema_changes_email(
 
     notify_org_managers_mock.assert_called_once_with(
         org_without_workspace,
-        f"To the admins of {org_without_workspace.name},\n\nThis email is to let you know that schema changes have been detected in your Dalgo pipeline.\n\nPlease visit {connections_page} and review the Pending Actions",
+        f"To the admins of {org_without_workspace.name},\n\nThis email is to let you know that schema changes have been detected in your Dalgo sources.\n\nPlease visit {connections_page} and review the Pending Actions",
     )
 
 

--- a/ddpui/tests/core/test_celery_tasks.py
+++ b/ddpui/tests/core/test_celery_tasks.py
@@ -378,6 +378,7 @@ def test_detect_schema_changes_for_org_send_schema_changes_email(
     )
     OrgSchemaChange.objects.create(org=org_without_workspace, connection_id="fake-connection-id")
     assert OrgSchemaChange.objects.filter(org=org_without_workspace).count() == 1
+    os.environ["FRONTEND_URL"] = "http://localhost:3000"
     with patch(
         "ddpui.ddpairbyte.airbytehelpers.fetch_and_update_org_schema_changes"
     ) as fetch_and_update_org_schema_changes_mock, patch(
@@ -393,10 +394,7 @@ def test_detect_schema_changes_for_org_send_schema_changes_email(
         detect_schema_changes_for_org(org_without_workspace)
     assert OrgSchemaChange.objects.filter(org=org_without_workspace).count() == 0
 
-    frontend_url = os.getenv("FRONTEND_URL")
-    if frontend_url.endswith("/"):
-        frontend_url = frontend_url[:-1]
-    connections_page = f"{frontend_url}/pipeline/ingest?tab=connections"
+    connections_page = "http://localhost:3000/pipeline/ingest?tab=connections"
 
     notify_org_managers_mock.assert_called_once_with(
         org_without_workspace,

--- a/ddpui/tests/core/test_celery_tasks.py
+++ b/ddpui/tests/core/test_celery_tasks.py
@@ -392,9 +392,15 @@ def test_detect_schema_changes_for_org_send_schema_changes_email(
         orguser.save()
         detect_schema_changes_for_org(org_without_workspace)
     assert OrgSchemaChange.objects.filter(org=org_without_workspace).count() == 0
+
+    frontend_url = os.getenv("FRONTEND_URL")
+    if frontend_url.endswith("/"):
+        frontend_url = frontend_url[:-1]
+    connections_page = f"{frontend_url}/pipeline/ingest?tab=connections"
+
     notify_org_managers_mock.assert_called_once_with(
         org_without_workspace,
-        """This email is to let you know that schema changes have been detected in your Dalgo pipeline, which require your review.""",
+        f"To the admins of {org_without_workspace.name},\n\nThis email is to let you know that schema changes have been detected in your Dalgo pipeline.\n\nPlease visit {connections_page} and review the Pending Actions",
     )
 
 


### PR DESCRIPTION
Plain text emails should go out using SES not SendGrid

And Org names need to be in the emails so we know who they're for when we get them in the role of org-managers