### PR TITLE
include end date in trial expiration email

### DIFF
--- a/ddpui/celeryworkers/tasks.py
+++ b/ddpui/celeryworkers/tasks.py
@@ -1078,7 +1078,7 @@ def setup_periodic_tasks(sender, **kwargs):
             name="check for long-running flow-runs",
         )
     sender.add_periodic_task(
-        crontab(minute=0, hour="*/12"),
+        crontab(minute=0, hour=0),
         check_org_plan_expiry_notify_people.s(),
         name="check org plan expiry and notify the right people",
     )

--- a/ddpui/celeryworkers/tasks.py
+++ b/ddpui/celeryworkers/tasks.py
@@ -1011,7 +1011,7 @@ def check_org_plan_expiry_notify_people():
                     org=org,
                     new_role__slug__in=roles_to_notify,
                 )
-                message = f"""This email is to let you know that your Dalgo plan for {org.name} is about to expire. Please renew it to continue using the services."""
+                message = f"""Your Dalgo plan for {org.name} will expire on {org_plan.end_date.strftime("%b %d, %Y")}. Please reach out to the Dalgo team at support@dalgo.org and renew your subscription to continue using the platform's services."""
                 subject = "Dalgo plan expiry"
                 for orguser in org_users:
                     send_text_message(orguser.user.email, subject, message)

--- a/ddpui/celeryworkers/tasks.py
+++ b/ddpui/celeryworkers/tasks.py
@@ -547,13 +547,6 @@ def update_dbt_core_block_schema_task(block_name, default_schema):
 
 
 @app.task()
-def delete_old_tasklocks():
-    """delete task locks which were created over 24 hours ago"""
-    onehourago = UTC.localize(datetime.now() - timedelta(seconds=24 * 3600))
-    TaskLock.objects.filter(locked_at__lt=onehourago).delete()
-
-
-@app.task()
 def delete_old_canvaslocks():
     """delete canvas locks which were created over 10 minutes ago"""
     tenminutesago = UTC.localize(datetime.now() - timedelta(seconds=600))
@@ -1073,7 +1066,6 @@ def setup_periodic_tasks(sender, **kwargs):
         schema_change_detection.s(),
         name="schema change detection",
     )
-    sender.add_periodic_task(60 * 1.0, delete_old_tasklocks.s(), name="remove old tasklocks")
     sender.add_periodic_task(60 * 1.0, delete_old_canvaslocks.s(), name="remove old canvaslocks")
     sender.add_periodic_task(
         crontab(minute=0, hour="*/6"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the organization's plan expiration notification to display the exact expiration date (in "Month Day, Year" format) and include a clear call to action, urging recipients to contact support for renewal.
- **Chores**
  - Removed the function responsible for deleting old task locks, streamlining the notification process.
  - Adjusted the scheduling for notifying organizations about plan expirations to run at midnight instead of every 12 hours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->