### PR TITLE
missing task id for schema catalog

### DIFF
--- a/ddpui/celeryworkers/tasks.py
+++ b/ddpui/celeryworkers/tasks.py
@@ -521,7 +521,7 @@ def get_schema_catalog_task(task_key, workspace_id, source_id):
         res = airbyte_service.get_source_schema_catalog(workspace_id, source_id)
         taskprogress.add(
             {
-                "message": "fetched catalog data",
+                "message": "Fetched catalog data",
                 "status": TaskProgressStatus.COMPLETED,
                 "result": res,
             }
@@ -531,12 +531,11 @@ def get_schema_catalog_task(task_key, workspace_id, source_id):
         logger.error(err)
         taskprogress.add(
             {
-                "message": "invalid error",
+                "message": "Failed to get schema catalog",
                 "status": TaskProgressStatus.FAILED,
-                "result": None,
+                "result": str(err),
             }
         )
-        return err
 
 
 @app.task(bind=False)

--- a/ddpui/tests/websockets/test_airbyte_consumer.py
+++ b/ddpui/tests/websockets/test_airbyte_consumer.py
@@ -59,7 +59,7 @@ def test_polling_celery_failed():
     polling_celery(consumer, task_key)
     consumer.respond.assert_called_once_with(
         WebsocketResponse(
-            data={}, message="Invalid credentials", status=WebsocketResponseStatus.ERROR
+            data={}, message="Failed to get schema catalog", status=WebsocketResponseStatus.ERROR
         )
     )
 


### PR DESCRIPTION
The issue was we were polling before the task progress object was created in redis. 

Also the celery task was returning an object `HttpError` which would break in backend , since we cannot return objects that are not serializable from celery tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error messages to provide clearer, more descriptive notifications during task failures.
  - Updated failure responses to ensure errors include detailed context.

- **New Features**
  - Added status notifications to signal the start of background tasks and indicate ongoing polling activities.

- **Style**
  - Standardized message capitalization for consistent and professional logging throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->