### PR TITLE
cms datainsights issue

### DIFF
--- a/ddpui/datainsights/warehouse/postgres.py
+++ b/ddpui/datainsights/warehouse/postgres.py
@@ -24,8 +24,8 @@ class PostgresClient(Warehouse):
             "host": creds["host"],
             "port": creds["port"],
             "dbname": creds["database"],
-            "user": creds["encoded_username"],
-            "password": creds["encoded_password"],
+            "user": creds["username"],
+            "password": creds["password"],
         }
 
         connection_string = "postgresql+psycopg2://"


### PR DESCRIPTION
Initially we were constructing a connection string & passing it to the sqlalchemy engine

```
connection_string = (
            "postgresql://{encoded_username}:{encoded_password}@{host}/{database}".format(**creds)
        )
```

This required, the password and the username to be encoded.

Now we just pass the connection args dictionary which doesn't require encoding of parameters. 

```
connection_args = {
            "host": creds["host"],
            "port": creds["port"],
            "dbname": creds["database"],
            "user": creds["username"],
            "password": creds["password"],
        }
```
