### PR TITLE
`cancel_queued_manual_job` wants to send `force` as a string

### DIFF
--- a/ddpui/api/pipeline_api.py
+++ b/ddpui/api/pipeline_api.py
@@ -766,7 +766,8 @@ def cancel_queued_manual_job(request, flow_run_id, payload: TaskStateSchema):
         if dataflow is None:
             raise HttpError(403, "You don't have access to this flow run")
 
-        res = prefect_service.cancel_queued_manual_job(flow_run_id, payload.dict())
+        cancellation_params = {"state": payload.state.dict(), "force": str(payload.force)}
+        res = prefect_service.cancel_queued_manual_job(flow_run_id, cancellation_params)
     except HttpError as http_error:
         # We handle HttpError separately to ensure the correct message is raised
         logger.exception(http_error)

--- a/ddpui/tests/api_tests/test_pipeline_api.py
+++ b/ddpui/tests/api_tests/test_pipeline_api.py
@@ -987,7 +987,7 @@ def test_cancel_queued_manual_job_success(
 
     assert response == {"success": True}
     mock_cancel_job.assert_called_once_with(
-        flow_run_id, {"state": {"name": "Cancelling", "type": "CANCELLING"}, "force": True}
+        flow_run_id, {"state": {"name": "Cancelling", "type": "CANCELLING"}, "force": "True"}
     )
 
 


### PR DESCRIPTION
prefect-proxy expects `force` as a string
the frontend sends a boolean in the payload
this PR converts that boolean to a string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the cancellation process for queued manual jobs to ensure correct parameters are sent.
- **Tests**
  - Updated tests to reflect changes in parameter types for job cancellation, ensuring accurate validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->