### PR TITLE
the flow run from prefect may not have a name when we first trigger it

### DIFF
--- a/ddpui/api/pipeline_api.py
+++ b/ddpui/api/pipeline_api.py
@@ -617,7 +617,7 @@ def post_run_prefect_org_deployment_task(request, deployment_id, payload: TaskPa
         PrefectFlowRun.objects.create(
             deployment_id=deployment_id,
             flow_run_id=res["flow_run_id"],
-            name=res["name"],
+            name=res.get("name", "name"),
             start_time=None,
             expected_start_time=djantotimezone.now(),
             total_run_time=-1,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when creating flow runs by preventing errors if certain information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->