### PR TITLE
1063 set the priority field of a bigquery cli profile block

### DIFF
--- a/ddpui/ddpairbyte/airbytehelpers.py
+++ b/ddpui/ddpairbyte/airbytehelpers.py
@@ -825,6 +825,10 @@ def create_warehouse(org: Org, payload: OrgWarehouseSchema):
     elif payload.wtype == "bigquery":
         credentials_json = json.loads(payload.airbyteConfig["credentials_json"])
         dbt_credentials = credentials_json
+        dbt_credentials["dataset_location"] = payload.airbyteConfig["dataset_location"]
+        dbt_credentials["transformation_priority"] = payload.airbyteConfig[
+            "transformation_priority"
+        ]
     elif payload.wtype == "snowflake":
         dbt_credentials = payload.airbyteConfig
 
@@ -847,7 +851,7 @@ def create_warehouse(org: Org, payload: OrgWarehouseSchema):
         warehouse.bq_location = destination["connectionConfiguration"]["dataset_location"]
     warehouse.save()
 
-    create_or_update_org_cli_block(org, warehouse, payload.airbyteConfig)
+    create_or_update_org_cli_block(org, warehouse, dbt_credentials)
 
     return None, None
 

--- a/ddpui/ddpairbyte/airbytehelpers.py
+++ b/ddpui/ddpairbyte/airbytehelpers.py
@@ -3,6 +3,7 @@ functions which work with airbyte and with the dalgo database
 """
 
 import json
+import re
 import os
 from typing import List
 from uuid import uuid4
@@ -733,7 +734,12 @@ def update_destination(org: Org, destination_id: str, payload: AirbyteDestinatio
             dbt_credentials["database"] = dbt_credentials["dbname"]
 
     elif warehouse.wtype == "bigquery":
-        dbt_credentials = json.loads(payload.config["credentials_json"])
+        if not re.match(r"^\*+$", payload.config["credentials_json"]):
+            dbt_credentials = json.loads(payload.config["credentials_json"])
+
+        dbt_credentials["dataset_location"] = payload.config["dataset_location"]
+        dbt_credentials["transformation_priority"] = payload.config["transformation_priority"]
+
     elif warehouse.wtype == "snowflake":
         dbt_credentials = update_dict_but_not_stars(payload.config)
 
@@ -852,9 +858,15 @@ def create_or_update_org_cli_block(org: Org, warehouse: OrgWarehouse, airbyte_cr
     """
 
     bqlocation = None
+    priority = None  # whether to run in "batch" mode or "interactive" mode for bigquery
     if warehouse.wtype == "bigquery":
         bqlocation = (
             airbyte_creds["dataset_location"] if "dataset_location" in airbyte_creds else None
+        )
+        priority = (
+            airbyte_creds["transformation_priority"]
+            if "transformation_priority" in airbyte_creds
+            else None
         )
     profile_name = None
     target = None
@@ -907,6 +919,7 @@ def create_or_update_org_cli_block(org: Org, warehouse: OrgWarehouse, airbyte_cr
                 bqlocation=bqlocation,
                 profilename=profile_name,
                 target=target,
+                priority=priority,
             )
         except Exception as error:
             logger.error(
@@ -933,6 +946,7 @@ def create_or_update_org_cli_block(org: Org, warehouse: OrgWarehouse, airbyte_cr
                 wtype=warehouse.wtype,
                 bqlocation=bqlocation,
                 credentials=dbt_creds,
+                priority=priority,
             )
         except Exception as error:
             logger.error(

--- a/ddpui/ddpprefect/prefect_service.py
+++ b/ddpui/ddpprefect/prefect_service.py
@@ -298,6 +298,7 @@ def create_dbt_cli_profile_block(
     wtype: str,
     bqlocation: str,
     credentials: dict,
+    priority: str = None,
 ) -> dict:
     """Create a dbt cli profile block in that has the warehouse information"""
     response = prefect_post(
@@ -312,6 +313,7 @@ def create_dbt_cli_profile_block(
             "wtype": wtype,
             "credentials": credentials,
             "bqlocation": bqlocation,
+            "priority": priority,
         },
     )
     return response
@@ -324,6 +326,7 @@ def update_dbt_cli_profile_block(
     target: str = None,
     credentials: dict = None,
     bqlocation: str = None,
+    priority: str = None,
 ):
     """Update the dbt cli profile for an org"""
     response = prefect_put(
@@ -338,6 +341,7 @@ def update_dbt_cli_profile_block(
             },
             "credentials": credentials,
             "bqlocation": bqlocation,
+            "priority": priority,
         },
     )
     return response

--- a/ddpui/tests/api_tests/test_user_org_api.py
+++ b/ddpui/tests/api_tests/test_user_org_api.py
@@ -677,7 +677,11 @@ def test_post_organization_warehouse_bigquery(orguser):
         wtype="bigquery",
         name="bigquery",
         destinationDefId="destinationDefId",
-        airbyteConfig={"credentials_json": "{}"},
+        airbyteConfig={
+            "credentials_json": "{}",
+            "dataset_location": "us-central1",
+            "transformation_priority": "batch",
+        },
     )
 
     response = post_organization_warehouse(request, payload)

--- a/ddpui/tests/helper/test_airbytehelpers.py
+++ b/ddpui/tests/helper/test_airbytehelpers.py
@@ -788,7 +788,11 @@ def test_update_destination_bigquery_config(
     payload = AirbyteDestinationUpdate(
         name="name",
         destinationDefId="destinationDefId",
-        config={"credentials_json": '{"key": "value"}'},
+        config={
+            "credentials_json": '{"key": "value"}',
+            "dataset_location": "LOCATION",
+            "transformation_priority": "batch",
+        },
     )
     mock_cli_profile_block = Mock(block_name="block-name")
     mock_dbt_project_params = Mock(
@@ -806,6 +810,8 @@ def test_update_destination_bigquery_config(
         warehouse,
         {
             "key": "value",
+            "dataset_location": "LOCATION",
+            "transformation_priority": "batch",
         },
     )
     mock_create_or_update_org_cli_block.assert_called_once()
@@ -1118,6 +1124,7 @@ def test_create_or_update_org_cli_block_update_case(
         bqlocation=None,
         profilename=yml_obj["profile"],
         target="default",
+        priority=None,
     )
 
 

--- a/ddpui/tests/services/test_prefect_service.py
+++ b/ddpui/tests/services/test_prefect_service.py
@@ -319,6 +319,7 @@ def test_create_dbt_cli_profile_block(mock_post: Mock):
         "wtype",
         credentials={"c1": "c2"},
         bqlocation=None,
+        priority=None,
     )
     assert response == "retval"
     mock_post.assert_called_once_with(
@@ -333,6 +334,7 @@ def test_create_dbt_cli_profile_block(mock_post: Mock):
             "wtype": "wtype",
             "credentials": {"c1": "c2"},
             "bqlocation": None,
+            "priority": None,
         },
     )
 


### PR DESCRIPTION
@fatchat our current setup should also be breaking creation of a new bigquery warehouse.  This PR also fixes that along with ability to send `priority` in the dbt cli profile block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring BigQuery dataset location and transformation priority when creating or updating warehouses.
  - Users can now specify transformation priority for BigQuery destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->