### PR TITLE
ability to switch versions on ai llm service

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -85,6 +85,7 @@ SCHEMA_REFRESH_TTL=180
 # LLM service
 LLM_SERVICE_API_URL="http://127.0.0.1:7001"
 LLM_SERVICE_API_KEY="<api key>"
+LLM_SERVICE_API_VER="" # can be empty or v1
 
 # Sentry
 SENTRY_DSN=


### PR DESCRIPTION
we willl be able to set `LLM_SERVICE_API_VER = "v1"` when this is merged & released https://github.com/DalgoT4D/ai-llm-service/pull/15

setting an empty string will default to our previous state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new environment variable to support optional API versioning for the LLM service configuration. No changes to existing functionality for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->