### PR TITLE
the password reset flows and accepting invitation should be unauthenticated

### DIFF
--- a/ddpui/api/user_org_api.py
+++ b/ddpui/api/user_org_api.py
@@ -394,6 +394,7 @@ def get_organizations_warehouses(request):
 
 @user_org_router.post(
     "/users/forgot_password/",
+    auth=None,
 )
 def post_forgot_password(request, payload: ForgotPasswordSchema):  # pylint: disable=unused-argument
     """step 1 of the forgot-password flow"""
@@ -403,7 +404,7 @@ def post_forgot_password(request, payload: ForgotPasswordSchema):  # pylint: dis
     return {"success": 1}
 
 
-@user_org_router.post("/users/reset_password/")
+@user_org_router.post("/users/reset_password/", auth=None)
 def post_reset_password(request, payload: ResetPasswordSchema):  # pylint: disable=unused-argument
     """step 2 of the forgot-password flow"""
     _, error = orguserfunctions.confirm_reset_password(payload)
@@ -432,7 +433,7 @@ def get_verify_email_resend(request):  # pylint: disable=unused-argument
     return {"success": 1}
 
 
-@user_org_router.post("/users/verify_email/")
+@user_org_router.post("/users/verify_email/", auth=None)
 def post_verify_email(request, payload: VerifyEmailSchema):  # pylint: disable=unused-argument
     """step 2 of the verify-email flow"""
     _, error = orguserfunctions.verify_email(payload)
@@ -472,24 +473,7 @@ def post_organization_user_invite_v1(request, payload: NewInvitationSchema):
     return retval
 
 
-@user_org_router.post(
-    "/organizations/users/invite/accept/",
-    response=OrgUserResponse,
-)
-def post_organization_user_accept_invite(
-    request, payload: AcceptInvitationSchema
-):  # pylint: disable=unused-argument
-    """User accepting the invite sent with a valid invite code"""
-    retval, error = orguserfunctions.accept_invitation(payload)
-    if error:
-        raise HttpError(400, error)
-    return retval
-
-
-@user_org_router.post(
-    "/v1/organizations/users/invite/accept/",
-    response=OrgUserResponse,
-)
+@user_org_router.post("/v1/organizations/users/invite/accept/", response=OrgUserResponse, auth=None)
 def post_organization_user_accept_invite_v1(
     request, payload: AcceptInvitationSchema
 ):  # pylint: disable=unused-argument

--- a/ddpui/tests/api_tests/test_user_org_api.py
+++ b/ddpui/tests/api_tests/test_user_org_api.py
@@ -27,7 +27,6 @@ from ddpui.api.user_org_api import (
     get_organizations_warehouses,
     post_organization_user_invite,
     post_organization_user_invite_v1,
-    post_organization_user_accept_invite,
     post_organization_user_accept_invite_v1,
     post_forgot_password,
     post_reset_password,

--- a/ddpui/tests/api_tests/test_user_org_api.py
+++ b/ddpui/tests/api_tests/test_user_org_api.py
@@ -1076,15 +1076,6 @@ def test_post_organization_user_invite_v1_user_exists(mock_sendgrid, orguser: Or
 
 
 # ================================================================================
-def test_post_organization_user_accept_invite_fail(orguser):
-    """failing test, invalid invite code"""
-    request = mock_request(orguser)
-    payload = AcceptInvitationSchema(invite_code="invalid-invite_code", password="password")
-
-    with pytest.raises(HttpError) as excinfo:
-        post_organization_user_accept_invite(request, payload)
-
-    assert str(excinfo.value) == "invalid invite code"
 
 
 def test_post_organization_user_accept_invite_v1_fail(orguser):
@@ -1096,35 +1087,6 @@ def test_post_organization_user_accept_invite_v1_fail(orguser):
         post_organization_user_accept_invite_v1(request, payload)
 
     assert str(excinfo.value) == "invalid invite code"
-
-
-def test_post_organization_user_accept_invite(orguser):
-    """success test, accepting an invitation"""
-    request = mock_request(orguser)
-    payload = AcceptInvitationSchema(invite_code="invite_code", password="password")
-
-    Invitation.objects.create(
-        invited_email="invited_email",
-        invited_by=orguser,
-        invited_on=timezone.as_ist(datetime.now()),
-        invite_code="invite_code",
-    )
-
-    assert (
-        OrgUser.objects.filter(
-            user__email="invited_email",
-        ).count()
-        == 0
-    )
-    response = post_organization_user_accept_invite(request, payload)
-    assert response.email == "invited_email"
-    assert (
-        OrgUser.objects.filter(
-            user__email="invited_email",
-        ).count()
-        == 1
-    )
-    assert UserAttributes.objects.filter(user__email="invited_email").exists()
 
 
 def test_post_organization_user_accept_invite_v1(orguser):
@@ -1153,34 +1115,6 @@ def test_post_organization_user_accept_invite_v1(orguser):
     assert UserAttributes.objects.filter(user__email="invited_email").exists()
 
 
-def test_post_organization_user_accept_invite_lowercase_email(orguser):
-    """success test, accepting an invitation"""
-    request = mock_request()
-    payload = AcceptInvitationSchema(invite_code="invite_code", password="password")
-
-    Invitation.objects.create(
-        invited_email="INVITED_EMAIL",
-        invited_by=orguser,
-        invited_on=timezone.as_ist(datetime.now()),
-        invite_code="invite_code",
-    )
-
-    assert (
-        OrgUser.objects.filter(
-            user__email__iexact="invited_email",
-        ).count()
-        == 0
-    )
-    response = post_organization_user_accept_invite(request, payload)
-    assert response.email == "invited_email"
-    assert (
-        OrgUser.objects.filter(
-            user__email="invited_email",
-        ).count()
-        == 1
-    )
-
-
 def test_post_organization_user_accept_invite_v1_lowercase_email(orguser):
     """success test, accepting an invitation"""
     request = mock_request()
@@ -1206,25 +1140,6 @@ def test_post_organization_user_accept_invite_v1_lowercase_email(orguser):
     assert OrgUser.objects.filter(user__email="invited_email", new_role=guest_role).count() == 1
 
 
-def test_post_organization_user_accept_invite_firstaccount_fail(orguser):
-    """failing test, invalid invite code"""
-    request = mock_request(orguser)
-    payload = AcceptInvitationSchema(
-        invite_code="invite_code",
-    )
-    Invitation.objects.create(
-        invited_email="invited_email",
-        invited_by=orguser,
-        invited_on=timezone.as_ist(datetime.now()),
-        invite_code="invite_code",
-    )
-
-    with pytest.raises(HttpError) as excinfo:
-        post_organization_user_accept_invite(request, payload)
-
-    assert str(excinfo.value) == "password is required"
-
-
 def test_post_organization_user_accept_invite_v1_firstaccount_fail(orguser):
     """failing test, invalid invite code"""
     request = mock_request(orguser)
@@ -1244,48 +1159,6 @@ def test_post_organization_user_accept_invite_v1_firstaccount_fail(orguser):
         post_organization_user_accept_invite_v1(request, payload)
 
     assert str(excinfo.value) == "password is required"
-
-
-def test_post_organization_user_accept_invite_secondaccount(orguser):
-    """success test, accepting an invitation"""
-    request = mock_request(orguser)
-    payload = AcceptInvitationSchema(invite_code="invite_code")
-
-    Invitation.objects.create(
-        invited_email="invited_email",
-        invited_by=orguser,
-        invited_on=timezone.as_ist(datetime.now()),
-        invite_code="invite_code",
-    )
-
-    authuser = User.objects.create_user(
-        username="invited_email", email="invited_email", password="oldpassword"
-    )
-    assert User.objects.filter(email="invited_email").count() == 1
-    anotherorg = Org.objects.create(name="anotherorg", slug="anotherorg")
-    OrgUser.objects.create(user=authuser, org=anotherorg)
-
-    assert (
-        OrgUser.objects.filter(
-            user__email="invited_email",
-        ).count()
-        == 1
-    )
-    response = post_organization_user_accept_invite(request, payload)
-    assert response.email == "invited_email"
-    assert (
-        OrgUser.objects.filter(
-            user__email="invited_email",
-        ).count()
-        == 2
-    )
-    assert (
-        OrgUser.objects.filter(user__email="invited_email", org__slug=orguser.org.slug).count() == 1
-    )
-    assert (
-        OrgUser.objects.filter(user__email="invited_email", org__slug=anotherorg.slug).count() == 1
-    )
-    assert User.objects.filter(email="invited_email").count() == 1
 
 
 def test_post_organization_user_accept_invite_v1_secondaccount(orguser):


### PR DESCRIPTION
JVF people are not able to login after clicking on the invite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated several user and organization-related endpoints to explicitly not require authentication.
- **Refactor**
	- Removed deprecated invitation acceptance endpoint and its related code.
- **Tests**
	- Removed outdated tests for the deprecated invitation acceptance endpoint; tests for the current version remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->