### PR TITLE
use a different default for unpivot cast_type in case of a bigquery

### DIFF
--- a/ddpui/dbt_automation/operations/unpivot.py
+++ b/ddpui/dbt_automation/operations/unpivot.py
@@ -31,9 +31,8 @@ def unpivot_dbt_sql(
     input_table = config["input"]
     field_name = config.get("unpivot_field_name", "field_name")
     value_name = config.get("unpivot_value_name", "value")
-    cast_datatype_to = config.get("cast_to", "varchar")
-    if warehouse.name == "bigquery":
-        cast_datatype_to = config.get("cast_to", "STRING")
+    default_cast_datatype = "STRING" if warehouse.name == "bigquery" else "varchar"
+    cast_datatype_to = config.get("cast_to", default_cast_datatype)
 
     if len(unpivot_on_columns) == 0:
         raise ValueError("No columns specified for unpivot")

--- a/ddpui/dbt_automation/operations/unpivot.py
+++ b/ddpui/dbt_automation/operations/unpivot.py
@@ -32,8 +32,8 @@ def unpivot_dbt_sql(
     field_name = config.get("unpivot_field_name", "field_name")
     value_name = config.get("unpivot_value_name", "value")
     cast_datatype_to = config.get("cast_to", "varchar")
-    if not cast_datatype_to and warehouse.name == "bigquery":
-        cast_datatype_to = "STRING"
+    if warehouse.name == "bigquery":
+        cast_datatype_to = config.get("cast_to", "STRING")
 
     if len(unpivot_on_columns) == 0:
         raise ValueError("No columns specified for unpivot")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified and streamlined the logic for determining the default cast datatype when unpivoting data, resulting in more consistent behavior across different data warehouses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->