### PR TITLE
pass the warehouse type to `update_dbt_cli_profile_block`

### DIFF
--- a/ddpui/api/dbt_api.py
+++ b/ddpui/api/dbt_api.py
@@ -225,6 +225,9 @@ def put_dbt_schema_v1(request, payload: OrgDbtTarget):
     org = orguser.org
     if org.dbt is None:
         raise HttpError(400, "create a dbt workspace first")
+    warehouse = OrgWarehouse.objects.filter(org=org).first()
+    if warehouse is None:
+        raise HttpError(400, "No warehouse configuration found for this organization")
 
     org.dbt.default_schema = payload.target_configs_schema
     org.dbt.save()
@@ -234,7 +237,6 @@ def put_dbt_schema_v1(request, payload: OrgDbtTarget):
 
     if cli_profile_block:
         logger.info(f"Updating the cli profile block's schema : {cli_profile_block.block_name}")
-        warehouse = OrgWarehouse.objects.filter(org=org).first()
         prefect_service.update_dbt_cli_profile_block(
             block_name=cli_profile_block.block_name,
             target=payload.target_configs_schema,

--- a/ddpui/api/dbt_api.py
+++ b/ddpui/api/dbt_api.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 from ninja import Router
 from ninja.errors import HttpError
 
-from ddpui import auth
 from ddpui.auth import has_permission
 from ddpui.celeryworkers.tasks import (
     clone_github_repo,
@@ -26,7 +25,7 @@ from ddpui.utils.constants import (
 from ddpui.ddpdbt import dbt_service, elementary_service
 from ddpui.ddpprefect import DBTCLIPROFILE, SECRET, prefect_service
 from ddpui.ddpprefect.schema import OrgDbtGitHub, OrgDbtSchema, OrgDbtTarget, PrefectSecretBlockEdit
-from ddpui.models.org import OrgPrefectBlockv1, Org
+from ddpui.models.org import OrgPrefectBlockv1, Org, OrgWarehouse
 from ddpui.models.org_user import OrgUser, OrgUserResponse
 from ddpui.core.orgdbt_manager import DbtProjectManager
 from ddpui.core.orgtaskfunctions import get_edr_send_report_task
@@ -231,15 +230,15 @@ def put_dbt_schema_v1(request, payload: OrgDbtTarget):
     org.dbt.save()
     logger.info("updated orgdbt")
 
-    cli_profile_block = OrgPrefectBlockv1.objects.filter(
-        org=orguser.org, block_type=DBTCLIPROFILE
-    ).first()
+    cli_profile_block = OrgPrefectBlockv1.objects.filter(org=org, block_type=DBTCLIPROFILE).first()
 
     if cli_profile_block:
         logger.info(f"Updating the cli profile block's schema : {cli_profile_block.block_name}")
+        warehouse = OrgWarehouse.objects.filter(org=org).first()
         prefect_service.update_dbt_cli_profile_block(
             block_name=cli_profile_block.block_name,
             target=payload.target_configs_schema,
+            wtype=warehouse.wtype,
         )
         logger.info(
             f"Successfully updated the cli profile block's schema : {cli_profile_block.block_name}"

--- a/ddpui/tests/api_tests/test_dbt_api.py
+++ b/ddpui/tests/api_tests/test_dbt_api.py
@@ -439,7 +439,6 @@ def test_post_run_dbt_commands_no_payload(orguser: OrgUser, f_org_tasks):
     ) as mock_task_progress, patch(
         "ddpui.celeryworkers.tasks.run_dbt_commands.delay", return_value=mock_celery_task
     ) as mock_run_dbt:
-
         response = post_run_dbt_commands(request)
 
         # Verify task ID is returned
@@ -473,7 +472,6 @@ def test_post_run_dbt_commands_with_payload(orguser: OrgUser, f_org_tasks):
     ) as mock_task_progress, patch(
         "ddpui.celeryworkers.tasks.run_dbt_commands.delay", return_value=mock_celery_task
     ) as mock_run_dbt:
-
         response = post_run_dbt_commands(request, payload)
 
         # Verify task ID is returned
@@ -512,7 +510,6 @@ def test_post_run_dbt_commands_task_locks(orguser: OrgUser, f_org_tasks):
     ), patch(
         "ddpui.api.dbt_api.TaskLock.objects.create", side_effect=mock_task_lock_create
     ) as mock_lock_create:
-
         response = post_run_dbt_commands(request)
 
         # Verify 3 task locks were created (for clean, deps, run)
@@ -551,7 +548,6 @@ def test_post_run_dbt_commands_exception_handling(orguser: OrgUser, f_org_tasks)
     ), patch(
         "ddpui.api.dbt_api.TaskLock.objects.create", side_effect=mock_task_lock_create
     ):
-
         # The function should raise the exception but still clean up locks
         with pytest.raises(Exception, match="Celery error"):
             post_run_dbt_commands(request)
@@ -583,7 +579,6 @@ def test_post_run_dbt_commands_task_filtering(orguser: OrgUser, f_org_tasks):
         ), patch(
             "ddpui.api.dbt_api.TaskLock.objects.create"
         ) as mock_lock_create:
-
             post_run_dbt_commands(request)
 
             # Should only create 3 locks for system tasks, not the client task

--- a/ddpui/tests/api_tests/test_dbt_api.py
+++ b/ddpui/tests/api_tests/test_dbt_api.py
@@ -364,6 +364,21 @@ def test_put_dbt_schema_v1_success(
         )
 
 
+def test_get_transform_type_none(orguser: OrgUser):
+    """tests get_transform_type"""
+    request = mock_request(orguser)
+    retval = get_transform_type(request)
+    assert retval == {"transform_type": None}
+
+
+def test_get_transform_type_non_none(orguser: OrgUser):
+    """tests get_transform_type"""
+    orguser.org.dbt = OrgDbt(transform_type="ui")
+    request = mock_request(orguser)
+    retval = get_transform_type(request)
+    assert retval == {"transform_type": "ui"}
+
+
 def test_get_elementary_setup_status_failure(orguser):
     """failure"""
     request = mock_request(orguser)


### PR DESCRIPTION
this was reported by janaagraha

https://discord.com/channels/1335141672937586693/1391238918753615953/1392721415287078932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of dbt CLI profile block updates to better account for the organization's warehouse type.

* **Tests**
  * Added comprehensive tests for dbt schema updates, transform type retrieval, and asynchronous dbt command execution.
  * Introduced fixtures to support testing of warehouse configurations, CLI profile blocks, and dbt tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->