### PR TITLE
Mark all as read - Notifications

### DIFF
--- a/ddpui/api/notifications_api.py
+++ b/ddpui/api/notifications_api.py
@@ -120,3 +120,14 @@ def get_unread_notifications_count(request):
         raise HttpError(400, error)
 
     return result
+
+
+@notification_router.put("/mark_all_as_read")
+def mark_all_notifications_as_read(request):
+    """Mark all notifications as read for the user"""
+    orguser: OrgUser = request.orguser
+    error, result = notifications_service.mark_all_notifications_as_read(orguser.id)
+    if error is not None:
+        raise HttpError(400, error)
+
+    return result

--- a/ddpui/core/notifications_service.py
+++ b/ddpui/core/notifications_service.py
@@ -380,3 +380,19 @@ def get_unread_notifications_count(
     ).count()
 
     return None, {"success": True, "res": unread_count}
+
+
+def mark_all_notifications_as_read(
+    orguser_id: int,
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """
+    Marks all notifications as read for the given user.
+    Returns the number of notifications updated.
+    """
+    try:
+        updated_count = NotificationRecipient.objects.filter(
+            recipient__id=orguser_id, read_status=False
+        ).update(read_status=True)
+        return None, {"success": True, "updated_count": updated_count}
+    except Exception as e:
+        return str(e), None


### PR DESCRIPTION
Add a new api endpoint and its corresponding service function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for users to mark all their notifications as read with a single action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->