### PR TITLE
Select columns for stream - backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 # C extensions
 *.so
 
+dbt-venv/
 # Distribution / packaging
 .Python
 build/

--- a/ddpui/ddpairbyte/airbyte_service.py
+++ b/ddpui/ddpairbyte/airbyte_service.py
@@ -780,6 +780,34 @@ def create_connection(
                 schema_cat["config"]["cursorField"] = []
                 schema_cat["config"]["primaryKey"] = []
 
+            if (
+                "columns" in selected_streams[stream_name]
+                and selected_streams[stream_name]["columns"]
+            ):
+                columns = selected_streams[stream_name]["columns"]
+                count = 0
+
+                for column in columns:
+                    if column.get("selected", False):
+                        count += 1
+
+                if count == len(columns):
+                    schema_cat["config"]["fieldSelectionEnabled"] = False
+                    schema_cat["config"]["selectedFields"] = []
+                else:
+                    schema_cat["config"]["fieldSelectionEnabled"] = True
+                    schema_cat["config"]["selectedFields"] = []
+
+                    for column in columns:
+                        if column.get("selected", False):
+                            schema_cat["config"]["selectedFields"].append(
+                                {"fieldPath": [column["name"]]}
+                            )
+            else:
+                # No column information or empty columns list - default to all columns selected
+                schema_cat["config"]["fieldSelectionEnabled"] = False
+                schema_cat["config"]["selectedFields"] = []
+
             payload["syncCatalog"]["streams"].append(schema_cat)
 
     res = abreq("connections/create", payload)

--- a/ddpui/ddpairbyte/airbyte_service.py
+++ b/ddpui/ddpairbyte/airbyte_service.py
@@ -863,6 +863,34 @@ def update_connection(
                 schema_cat["config"]["cursorField"] = []
                 schema_cat["config"]["primaryKey"] = []
 
+            if (
+                "columns" in selected_streams[stream_name]
+                and selected_streams[stream_name]["columns"]
+            ):
+                columns = selected_streams[stream_name]["columns"]
+                count = 0
+
+                for column in columns:
+                    if column.get("selected", False):
+                        count += 1
+
+                if count == len(columns):
+                    schema_cat["config"]["fieldSelectionEnabled"] = False
+                    schema_cat["config"]["selectedFields"] = []
+                else:
+                    schema_cat["config"]["fieldSelectionEnabled"] = True
+                    schema_cat["config"]["selectedFields"] = []
+
+                    for column in columns:
+                        if column.get("selected", False):
+                            schema_cat["config"]["selectedFields"].append(
+                                {"fieldPath": [column["name"]]}
+                            )
+            else:
+                # No column information or empty columns list - default to all columns selected
+                schema_cat["config"]["fieldSelectionEnabled"] = False
+                schema_cat["config"]["selectedFields"] = []
+
             current_connection["syncCatalog"]["streams"].append(schema_cat)
 
     res = abreq("connections/update", current_connection)


### PR DESCRIPTION
## Summary

Fixes: #873 
Added the logic of sending the columns data correctly in the way that airbyte required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved stream configuration to support field-level selection, allowing users to choose specific columns for synchronization when setting up connections.
* **Tests**
  * Added comprehensive tests covering various scenarios of column selection and field-level sync configuration for streams.
* **Chores**
  * Updated `.gitignore` to exclude the `dbt-venv/` directory from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->