### PR TITLE
1127 restore missing crons of prefect deployments

### DIFF
--- a/ddpui/core/orgtaskfunctions.py
+++ b/ddpui/core/orgtaskfunctions.py
@@ -236,7 +236,9 @@ def delete_orgtask(org_task: OrgTask):
             parameters["config"]["tasks"] = tasks_to_keep
             # logger.info(parameters)
             if len(parameters["config"]["tasks"]) > 0:
-                payload = PrefectDataFlowUpdateSchema3(deployment_params=parameters)
+                payload = PrefectDataFlowUpdateSchema3(
+                    deployment_params=parameters, cron=dataflow.cron
+                )
                 prefect_service.update_dataflow_v1(dataflow.deployment_id, payload)
                 logger.info("updated deployment %s", dataflow.deployment_name)
             else:

--- a/ddpui/management/commands/fixdeploymentschedule.py
+++ b/ddpui/management/commands/fixdeploymentschedule.py
@@ -36,7 +36,6 @@ class Command(BaseCommand):
             return flow_run
 
     def handle(self, *args, **options):
-
         # fetch deployments which have a cron in our db
         query = Q(dataflow_type="orchestrate", cron__isnull=False) & ~Q(cron="")
         if options["org"]:
@@ -45,7 +44,6 @@ class Command(BaseCommand):
             query &= Q(deployment_id=options["deployment_id"])
 
         for odf in OrgDataFlowv1.objects.filter(query):
-
             # fetch the corresponding prefect object
             deployment = prefect_service.get_deployment(odf.deployment_id)
 

--- a/ddpui/management/commands/fixdeploymentschedule.py
+++ b/ddpui/management/commands/fixdeploymentschedule.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         # fetch deployments which have a cron in our db
-        query = Q(dataflow_type="orchestrate", cron__isnull=False)
+        query = Q(dataflow_type="orchestrate", cron__isnull=False) & ~Q(cron="")
         if options["org"]:
             query &= Q(org__slug=options["org"])
         if options["deployment_id"]:

--- a/ddpui/management/commands/fixdeploymentschedule.py
+++ b/ddpui/management/commands/fixdeploymentschedule.py
@@ -1,0 +1,93 @@
+"""set prefect deployment schedule from saved cron"""
+
+import requests
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from ddpui.ddpprefect import prefect_service
+from ddpui.models.org import OrgDataFlowv1
+from ddpui.ddpprefect.schema import PrefectDataFlowUpdateSchema3
+
+
+class Command(BaseCommand):
+    """set prefect deployment schedule from saved cron"""
+
+    def add_arguments(self, parser):
+        parser.add_argument("--org", type=str, help="Org slug")
+        parser.add_argument("--action", choices=["show", "fix"])
+        parser.add_argument("--deployment-id", help="optional")
+        parser.add_argument("--verbose", action="store_true")
+
+    def fetch_latest_flow_run(self, deployment_id: str) -> dict:
+        """fetch the latest flow run for the deployment"""
+        flow_runs = requests.post(
+            "http://localhost:4200/api/flow_runs/filter",
+            json={
+                "sort": "EXPECTED_START_TIME_DESC",
+                "limit": 1,
+                "deployments": {
+                    "operator": "and_",
+                    "id": {"any_": [deployment_id]},
+                },
+            },
+            timeout=10,
+        ).json()
+        if flow_runs:
+            flow_run = flow_runs[0]
+            return flow_run
+
+    def handle(self, *args, **options):
+
+        # fetch deployments which have a cron in our db
+        query = Q(dataflow_type="orchestrate", cron__isnull=False)
+        if options["org"]:
+            query &= Q(org__slug=options["org"])
+        if options["deployment_id"]:
+            query &= Q(deployment_id=options["deployment_id"])
+
+        for odf in OrgDataFlowv1.objects.filter(query):
+
+            # fetch the corresponding prefect object
+            deployment = prefect_service.get_deployment(odf.deployment_id)
+
+            # does it have a cron?
+            if deployment["cron"]:
+                if options["verbose"]:
+                    self.stdout.write(
+                        f"{odf.org.slug} deployment {odf.deployment_name} has a cron! {deployment['cron']} ... vs saved {odf.cron}"
+                    )
+                continue
+
+            # if there is no cron, then this should be False
+            assert not deployment["isScheduleActive"]
+
+            latest_flow_run = self.fetch_latest_flow_run(odf.deployment_id)
+            if options["action"] == "show":
+                if latest_flow_run:
+                    last_run_date = latest_flow_run["expected_start_time"][: len("yyyy-mm-dd")]
+                    self.stdout.write(
+                        " / ".join(
+                            map(
+                                str,
+                                [
+                                    odf.org.slug,
+                                    odf.deployment_id,
+                                    odf.deployment_name,
+                                    last_run_date,
+                                    odf.cron,
+                                ],
+                            )
+                        )
+                    )
+
+            elif options["action"] == "fix":
+                prefect_service.update_dataflow_v1(
+                    odf.deployment_id,
+                    PrefectDataFlowUpdateSchema3(
+                        cron=odf.cron, deployment_params=deployment["parameters"]
+                    ),
+                )
+                if latest_flow_run and not odf.cron.endswith("*"):
+                    last_run_date = latest_flow_run["expected_start_time"][: len("yyyy-mm-dd")]
+                    self.stdout.write(
+                        f"do you need to run the deployment now? deployment is {odf.deployment_name} cron is {odf.cron} last run was on {last_run_date}"
+                    )

--- a/ddpui/management/commands/manage-transform-tasks.py
+++ b/ddpui/management/commands/manage-transform-tasks.py
@@ -74,7 +74,9 @@ class Command(BaseCommand):
                 try:
                     prefect_service.update_dataflow_v1(
                         dataflow.deployment_id,
-                        PrefectDataFlowUpdateSchema3(deployment_params={"config": config}),
+                        PrefectDataFlowUpdateSchema3(
+                            deployment_params={"config": config}, cron=dataflow.cron
+                        ),
                     )
                 except Exception as err:
                     logger.error(

--- a/ddpui/management/commands/set_timeout_prefect_airbyte_tasks_in_deployments.py
+++ b/ddpui/management/commands/set_timeout_prefect_airbyte_tasks_in_deployments.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
                     )
                     task["timeout"] = timeout
 
-            payload = PrefectDataFlowUpdateSchema3(deployment_params=parameters)
+            payload = PrefectDataFlowUpdateSchema3(deployment_params=parameters, cron=dataflow.cron)
             prefect_service.update_dataflow_v1(dataflow.deployment_id, payload)
             self.stdout.write(
                 f"updated timeout for deployment {dataflow.deployment_name} with id : {dataflow.deployment_id}"

--- a/ddpui/management/commands/update_dbt_binary_path.py
+++ b/ddpui/management/commands/update_dbt_binary_path.py
@@ -117,7 +117,7 @@ class Command(BaseCommand):
                     if not dry_run:
                         prefect_put(
                             f"v1/deployments/{deployment.deployment_id}",
-                            {"deployment_params": deployment_params},
+                            {"deployment_params": deployment_params, "cron": deployment.cron},
                         )
                         self.stdout.write(
                             self.style.SUCCESS(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a management command to view and update Prefect deployment schedules based on saved cron expressions, with options to filter, show details, and synchronize schedules.
* **Bug Fixes**
  * Ensured that cron schedules are preserved when updating deployment parameters to prevent accidental overwrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->