### PR TITLE
wrong credentials should give a proper error message and increase warehouse name field length

### DIFF
--- a/ddpui/routes.py
+++ b/ddpui/routes.py
@@ -58,8 +58,7 @@ def ninja_default_error_handler(
     request, exc: Exception
 ):  # pylint: disable=unused-argument # skipcq PYL-W0613
     """Handle any other exception raised in the apis"""
-    print(exc)
-    return Response({"detail": "something went wrong"}, status=500)
+    return Response({"detail": str(exc)}, status=500)
 
 
 # tag routes to specify sections in docs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses now display the specific exception message instead of a generic error message when a server error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->