### PR TITLE
Hotfix/retry failed runs

### DIFF
--- a/ddpui/management/commands/clear_role_permissions.py
+++ b/ddpui/management/commands/clear_role_permissions.py
@@ -1,0 +1,71 @@
+import os
+import json
+from django.core.management.base import BaseCommand
+from ddpui.utils.redis_client import RedisClient
+from ddpui.utils.custom_logger import CustomLogger
+
+logger = CustomLogger("ddpui")
+
+
+class Command(BaseCommand):
+    help = "Clear role_permission key from Redis cache"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Deletes the role_permission key from Redis without making any changes",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+
+        # Get the role permissions key from environment
+        role_permissions_key = os.getenv("ROLE_PERMISSIONS_REDIS_KEY", "dalgo_permissions_key")
+
+        try:
+            redis_client = RedisClient.get_instance()
+
+            # Check if role_permission key exists
+            if redis_client.exists(role_permissions_key):
+                if dry_run:
+                    self.stdout.write(
+                        self.style.WARNING(f"DRY RUN - Would delete key: {role_permissions_key}")
+                    )
+                    # Show the type and some info about the key
+                    key_type = redis_client.type(role_permissions_key).decode("utf-8")
+                    self.stdout.write(f"Key type: {key_type}")
+                    if key_type == "string":
+                        try:
+                            value = redis_client.get(role_permissions_key)
+                            if value:
+                                permissions_data = json.loads(value)
+                                self.stdout.write(
+                                    f"Contains permissions for {len(permissions_data)} roles"
+                                )
+                        except json.JSONDecodeError:
+                            self.stdout.write("Key contains non-JSON data")
+                else:
+                    # Delete the key
+                    result = redis_client.delete(role_permissions_key)
+                    if result:
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                f"Successfully deleted {role_permissions_key} key from Redis"
+                            )
+                        )
+                        logger.info(f"Cleared role permissions cache key: {role_permissions_key}")
+                    else:
+                        self.stdout.write(
+                            self.style.WARNING(
+                                f"{role_permissions_key} key was not found or already deleted"
+                            )
+                        )
+            else:
+                self.stdout.write(
+                    self.style.WARNING(f"{role_permissions_key} key not found in Redis")
+                )
+
+        except Exception as e:
+            self.stdout.write(self.style.ERROR(f"Error clearing {role_permissions_key} key: {e}"))
+            logger.error(f"Error clearing role permissions key: {e}", exc_info=True)

--- a/ddpui/utils/webhook_helpers.py
+++ b/ddpui/utils/webhook_helpers.py
@@ -261,8 +261,8 @@ def update_flow_run_for_deployment(deployment_id: str, state: str, flow_run: dic
         logger.info("updating the flow run in db")
         create_or_update_flowrun(flow_run, deployment_id, state)
 
-        # retry flow run if infra went down
-        if state == FLOW_RUN_CRASHED_STATE_NAME:
+        # retry flow run if infra went down or in case of failures
+        if state in [FLOW_RUN_CRASHED_STATE_NAME, FLOW_RUN_FAILED_STATE_NAME]:
             prefect_flow_run = PrefectFlowRun.objects.filter(flow_run_id=flow_run_id).first()
             retry_crashed_flow_runs = os.getenv("PREFECT_RETRY_CRASHED_FLOW_RUNS", "0").lower() in [
                 "1",

--- a/seed/002_permissions.json
+++ b/seed/002_permissions.json
@@ -3,8 +3,8 @@
         "model": "ddpui.Permission",
         "pk": 1,
         "fields": {
-            "name": "Can View Dashboard",
-            "slug": "can_view_dashboard"
+            "name": "Can View Pipeline Overview",
+            "slug": "can_view_pipeline_overview"
         }
     },
     {


### PR DESCRIPTION
1. Main enhancemnent of retrying flow runs on failure
2. Minor change in the name of permission for view pipeline overview page. Seeder will need to be run
3. Command to reset the cache of role permissions mapping to pick up the above change