### PR TITLE
fix role-permissions

### DIFF
--- a/seed/003_role_permissions.json
+++ b/seed/003_role_permissions.json
@@ -2235,7 +2235,7 @@
     "model": "ddpui.RolePermission",
     "pk": 276,
     "fields": {
-      "role": 4,
+      "role": 2,
       "permission": 73
     }
   },


### PR DESCRIPTION
  Chart Permissions (create/edit/delete):
  - Super User ✓
  - Account Manager ✓
  - Pipeline Manager ✓
  - Analyst ✓
  - Guest ✗

 Everyone except Guest users can create, edit, and delete charts. Guest users can only view charts but cannot
   modify them in any way.

  Manage Organization Default Dashboard Permission:
  - Super User ✓
  - Account Manager ✓ ← (moved from Analyst)
  - Pipeline Manager ✗
  - Analyst ✗ ← (removed)
  - Guest ✗

  Only Super Users and Account Managers can now manage organization default dashboards.