### PR TITLE
Cannot delete a source or a connection if its being used in a pipeline ----> SNEHA's Issue

### DIFF
--- a/ddpui/ddpairbyte/airbytehelpers.py
+++ b/ddpui/ddpairbyte/airbytehelpers.py
@@ -914,6 +914,13 @@ def delete_source(org: Org, source_id: str):
     connections_of_source = [
         conn["connectionId"] for conn in connections if conn["sourceId"] == source_id
     ]
+    connection_names = [conn["name"] for conn in connections if conn["sourceId"] == source_id]
+
+    if connections_of_source:
+        raise HttpError(
+            403,
+            f"Cannot delete source. It is used in connection(s): {', '.join(connection_names)}. Please remove these connections first.",
+        )
 
     # Fetch org tasks and deployments mapped to each connection_id
     org_tasks = OrgTask.objects.filter(org=org, connection_id__in=connections_of_source).all()

--- a/ddpui/ddpairbyte/airbytehelpers.py
+++ b/ddpui/ddpairbyte/airbytehelpers.py
@@ -918,7 +918,21 @@ def delete_source(org: Org, source_id: str):
     # Fetch org tasks and deployments mapped to each connection_id
     org_tasks = OrgTask.objects.filter(org=org, connection_id__in=connections_of_source).all()
 
-    # Fetch dataflows(manual or pipelines)
+    # Check if source is being used in orchestrate pipelines before deletion
+    pipeline_usage = DataflowOrgTask.objects.filter(
+        orgtask__in=org_tasks, dataflow__dataflow_type="orchestrate"
+    )
+
+    if pipeline_usage.exists():
+        # Get pipeline names for better error message
+        pipeline_names = list(pipeline_usage.values_list("dataflow__name", flat=True).distinct())
+        raise HttpError(
+            403,
+            f"Cannot delete source. It's being used in pipeline(s): {', '.join(pipeline_names)}. "
+            f"Please remove the connections from the pipeline(s) first.",
+        )
+
+    # Fetch dataflows(manual or pipelines) - only proceed if validation passed
     df_orgtasks = DataflowOrgTask.objects.filter(orgtask__in=org_tasks).all()
     dataflows = [df_orgtask.dataflow for df_orgtask in df_orgtasks]
 

--- a/ddpui/ddpairbyte/deleteconnection.py
+++ b/ddpui/ddpairbyte/deleteconnection.py
@@ -2,21 +2,39 @@ from ddpui.models.org import (
     Org,
     OrgSchemaChange,
 )
-from ddpui.models.tasks import OrgTask
+from ddpui.models.tasks import OrgTask, DataflowOrgTask
 from ddpui.utils.custom_logger import CustomLogger
 from ddpui.core.orgtaskfunctions import delete_orgtask
 from ddpui.ddpairbyte import airbyte_service
+from ninja.errors import HttpError
 
 logger = CustomLogger("airbyte")
 
 
 def delete_org_connection(org: Org, connection_id: str):
     """deletes an airbyte connection"""
-    # remove all orgtasks (sync, clear, ...)
-    for org_task in OrgTask.objects.filter(
+    # Find org tasks for this connection
+    org_tasks = OrgTask.objects.filter(
         org=org,
         connection_id=connection_id,
-    ):
+    )
+
+    # Check if connection is being used in orchestrate pipelines before deletion
+    pipeline_usage = DataflowOrgTask.objects.filter(
+        orgtask__in=org_tasks, dataflow__dataflow_type="orchestrate"
+    )
+
+    if pipeline_usage.exists():
+        # Get pipeline names for better error message
+        pipeline_names = list(pipeline_usage.values_list("dataflow__name", flat=True).distinct())
+        raise HttpError(
+            403,
+            f"Cannot delete connection. It's being used in pipeline(s): {', '.join(pipeline_names)}. "
+            f"Please remove the connection from the pipeline(s) first.",
+        )
+
+    # remove all orgtasks (sync, clear, ...)
+    for org_task in org_tasks:
         delete_orgtask(org_task)
 
     # delete airbyte connection


### PR DESCRIPTION
[https://discord.com/channels/1335141672937586693/1413047345901469696](https://discord.com/channels/1335141672937586693/1413047345901469696)

1. Abhishek delete a source which was used to create a connection which was then being used in a pipeline. 
2. Now that pipeline had multiple connections too. Hence whole pipeline got deleted. 

Ideal scenario-> If we are deleting a source or a connection and it is being used in a pipeline user should get error. First manually remove it from the pipeline and then delete it. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added safeguards when deleting sources and connections: deletion is blocked if they are referenced by existing connections or orchestrated pipelines. Users receive clear messages listing the dependent items and guidance to remove references first.

- Bug Fixes
  - Prevents accidental deletion of in-use resources that could disrupt pipelines.
  - Maintains cleanup of related deployments/tasks when deletion is permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->