### PR TITLE
remove the ssl_mode key; looks like pyscopg throws an error on this

### DIFF
--- a/ddpui/dbt_automation/utils/postgres.py
+++ b/ddpui/dbt_automation/utils/postgres.py
@@ -43,7 +43,10 @@ class PostgresClient(WarehouseInterface):
 
         # ssl_mode is an alias for sslmode
         if "ssl_mode" in conn_info:
-            conn_info["sslmode"] = conn_info["ssl_mode"]
+            # Only map alias if canonical key not already provided
+            if "sslmode" not in conn_info:
+                conn_info["sslmode"] = conn_info["ssl_mode"]
+            # Always drop the alias
             del conn_info["ssl_mode"]
 
         if "sslmode" in conn_info:

--- a/ddpui/dbt_automation/utils/postgres.py
+++ b/ddpui/dbt_automation/utils/postgres.py
@@ -44,6 +44,7 @@ class PostgresClient(WarehouseInterface):
         # ssl_mode is an alias for sslmode
         if "ssl_mode" in conn_info:
             conn_info["sslmode"] = conn_info["ssl_mode"]
+            del conn_info["ssl_mode"]
 
         if "sslmode" in conn_info:
             # sslmode can be a string or a boolean or a dict

--- a/ddpui/ddpairbyte/airbytehelpers.py
+++ b/ddpui/ddpairbyte/airbytehelpers.py
@@ -925,20 +925,6 @@ def delete_source(org: Org, source_id: str):
     # Fetch org tasks and deployments mapped to each connection_id
     org_tasks = OrgTask.objects.filter(org=org, connection_id__in=connections_of_source).all()
 
-    # Check if source is being used in orchestrate pipelines before deletion
-    pipeline_usage = DataflowOrgTask.objects.filter(
-        orgtask__in=org_tasks, dataflow__dataflow_type="orchestrate"
-    )
-
-    if pipeline_usage.exists():
-        # Get pipeline names for better error message
-        pipeline_names = list(pipeline_usage.values_list("dataflow__name", flat=True).distinct())
-        raise HttpError(
-            403,
-            f"Cannot delete source. It's being used in pipeline(s): {', '.join(pipeline_names)}. "
-            f"Please remove the connections from the pipeline(s) first.",
-        )
-
     # Fetch dataflows(manual or pipelines) - only proceed if validation passed
     df_orgtasks = DataflowOrgTask.objects.filter(orgtask__in=org_tasks).all()
     dataflows = [df_orgtask.dataflow for df_orgtask in df_orgtasks]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL connection: alternative SSL-mode keys are used only if an explicit sslmode isn’t provided; the alternate key is then removed to avoid leaking or overwriting configuration.
  * Deleting an Airbyte source is now blocked when it’s referenced by any connection or dataflow, returning a 403 with a detailed list of conflicting names.

* **Tests**
  * Updated tests to assert the 403 error/message for in-use sources and to verify successful deletion of unused sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->