### PR TITLE
Fix horizontal bar chart bar names and tooltip display

### DIFF
--- a/ddpui/core/charts/charts_service.py
+++ b/ddpui/core/charts/charts_service.py
@@ -699,11 +699,14 @@ def transform_data_for_chart(
 
     if payload.chart_type == "bar":
         if payload.computation_type == "raw":
+            # Get category data (bar names)
+            category_data = [
+                convert_value(safe_get_value(row, payload.x_axis, null_label)) for row in results
+            ]
+
             return {
-                "xAxisData": [
-                    convert_value(safe_get_value(row, payload.x_axis, null_label))
-                    for row in results
-                ],
+                "xAxisData": category_data,  # For vertical bars
+                "yAxisData": category_data,  # For horizontal bars
                 "series": [
                     {
                         "name": payload.y_axis,
@@ -787,7 +790,8 @@ def transform_data_for_chart(
                         legend_data.append(dimension)
 
                 return {
-                    "xAxisData": x_axis_data,
+                    "xAxisData": x_axis_data,  # For vertical bars
+                    "yAxisData": x_axis_data,  # For horizontal bars
                     "series": series_data,
                     "legend": legend_data,
                 }
@@ -823,7 +827,8 @@ def transform_data_for_chart(
                     legend_data.append(display_name)
 
                 return {
-                    "xAxisData": x_axis_data,
+                    "xAxisData": x_axis_data,  # For vertical bars
+                    "yAxisData": x_axis_data,  # For horizontal bars
                     "series": series_data,
                     "legend": legend_data,
                 }


### PR DESCRIPTION
This commit fixes two issues with horizontal bar charts:

1. Bar names not showing: The backend transform_data_for_chart function was only returning xAxisData, but horizontal bar charts need yAxisData for the category axis (bar names).

<img width="1391" height="636" alt="Screenshot 2025-11-01 at 4 40 53 PM" src="https://github.com/user-attachments/assets/4b8d096a-5520-4d81-b38c-a3bf2722eb22" />


2. Tooltip not working on hover: With missing axis data, tooltips could not properly display when hovering over bars.

Changes:
- Added yAxisData to all bar chart data transformation return values
- Updated raw data bar charts to include both xAxisData and yAxisData
- Updated aggregated bar charts (with/without extra dimension) to include both axis data arrays
- Category data is now available for both vertical (xAxis) and horizontal (yAxis) orientations

The ECharts config generator already correctly uses yAxisData for horizontal bars (line 161), so this provides the missing data.

Files modified:
- ddpui/core/charts/charts_service.py: Added yAxisData to transform functions for bar charts (lines 708-710, 793-797, 829-834)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected axis data handling for bar, line, and pie charts in both raw and aggregated data views.
  * Enhanced consistency of axis representation when additional dimensions are present in chart configurations.
  * Improved alignment and display of chart axes across different visualization types for accurate rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->