### PR TITLE
Increase pylint fail-under threshold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,7 +286,7 @@ testpaths = [
 
 [tool.pylint.messages_control]
 max-line-length = 200
-fail-under = 6.5
+fail-under = 8.5
 disable = [
   "missing-module-docstring",
   "broad-exception-raised",


### PR DESCRIPTION
Update [tool.pylint.messages_control].fail-under from 6.5 to 8.5 as part of improving the repo's pylint score.

Closes #867.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes.** This release contains internal development configuration updates to code quality standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->