### PR TITLE
enhance ChartValidator to support additional number formats: 'indian'…

### DIFF
--- a/ddpui/core/charts/chart_validator.py
+++ b/ddpui/core/charts/chart_validator.py
@@ -178,9 +178,11 @@ class ChartValidator:
                 "comma",
                 "percentage",
                 "currency",
+                "indian",
+                "international",
             ]:
                 raise ChartValidationError(
-                    f"Invalid number format '{number_format}'. Must be one of: default, comma, percentage, currency"
+                    f"Invalid number format '{number_format}'. Must be one of: default, comma, percentage, currency,indian, international"
                 )
 
             decimal_places = customizations.get("decimalPlaces")
@@ -222,9 +224,9 @@ class ChartValidator:
             customizations = extra_config.get("customizations", {})
             if "numberFormat" in customizations:
                 number_format = customizations["numberFormat"]
-                if number_format not in ["default", "comma", "percentage", "currency"]:
+                if number_format not in ["default", "comma", "percentage", "currency", "indian", "international"]:
                     raise ChartValidationError(
-                        f"Invalid number format '{number_format}'. Must be one of: default, comma, percentage, currency"
+                        f"Invalid number format '{number_format}'. Must be one of: default, comma, percentage, currency, indian, international"
                     )
 
             return True, None


### PR DESCRIPTION
-Added support for two new number format options in ChartValidator: indian and international                   
  - Updated validation logic in both validate_number_card_chart and validate_table_chart methods to accept the new
   formats 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "indian" and "international" number formats in charts. These new options extend the chart formatting capabilities beyond the existing formats (default, comma, percentage, currency), allowing better localization and presentation of numerical data to regional preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->