### PR TITLE
make sure warehouse location for bigquery gets updated in our db also

### DIFF
--- a/ddpui/ddpairbyte/airbytehelpers.py
+++ b/ddpui/ddpairbyte/airbytehelpers.py
@@ -763,6 +763,10 @@ def update_destination(org: Org, destination_id: str, payload: AirbyteDestinatio
         dbt_credentials["dataset_location"] = payload.config["dataset_location"]
         dbt_credentials["transformation_priority"] = payload.config["transformation_priority"]
 
+        if warehouse.bq_location != payload.config["dataset_location"]:
+            warehouse.bq_location = payload.config["dataset_location"]
+            warehouse.save()
+
     elif warehouse.wtype == "snowflake":
         dbt_credentials = update_dict_but_not_stars(payload.config)
 

--- a/ddpui/tests/helper/test_airbytehelpers.py
+++ b/ddpui/tests/helper/test_airbytehelpers.py
@@ -834,6 +834,9 @@ def test_update_destination_bigquery_config(
     )
     mock_create_or_update_org_cli_block.assert_called_once()
 
+    warehouse.refresh_from_db()
+    assert warehouse.bq_location == "LOCATION"
+
 
 @patch(
     "ddpui.ddpairbyte.airbyte_service.update_destination",


### PR DESCRIPTION
UPdated this for tap since their bq_location was null in our db for some reason

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Fixed BigQuery warehouse location settings not being properly saved when updating destination configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->