### PR TITLE
author can do hard delete as long as no other user has commented

### DIFF
--- a/ddpui/core/reports/comment_service.py
+++ b/ddpui/core/reports/comment_service.py
@@ -166,18 +166,37 @@ class CommentService:
         org: Org,
         orguser: OrgUser,
     ) -> None:
-        """Soft-delete a comment. Author-only."""
+        """Delete a comment. Author-only.
+
+        Hard-deletes if no other user has commented in the thread (same
+        snapshot + target_type + chart_id). Soft-deletes otherwise so the
+        "This message was deleted" placeholder is shown alongside others'
+        comments.
+        """
         comment = CommentService._get_comment(comment_id, org)
 
         if comment.author != orguser:
             raise CommentPermissionError("You can only delete your own comments")
 
-        comment.is_deleted = True
-        comment.content = ""
-        comment.mentioned_emails = []
-        comment.save()
+        # Check if another author has commented in this thread
+        thread_query = Q(
+            snapshot=comment.snapshot,
+            target_type=comment.target_type,
+        )
+        if comment.target_type == CommentTargetType.CHART:
+            thread_query &= Q(snapshot_chart_id=comment.snapshot_chart_id)
 
-        logger.info(f"Soft-deleted comment {comment_id}")
+        has_other_authors = Comment.objects.filter(thread_query).exclude(author=orguser).exists()
+
+        if has_other_authors:
+            comment.is_deleted = True
+            comment.content = ""
+            comment.mentioned_emails = []
+            comment.save()
+            logger.info(f"Soft-deleted comment {comment_id}")
+        else:
+            comment.delete()
+            logger.info(f"Hard-deleted comment {comment_id}")
 
     # language=SQL
     _COMMENT_STATES_SQL = """

--- a/ddpui/tests/api_tests/test_comment_api.py
+++ b/ddpui/tests/api_tests/test_comment_api.py
@@ -494,14 +494,12 @@ class TestDeleteComment:
             author=orguser,
             org=org,
         )
+        comment_id = comment.id
         request = mock_request(orguser)
-        response = delete_comment(request, snapshot.id, comment.id)
+        response = delete_comment(request, snapshot.id, comment_id)
         assert response["success"] is True
-        comment.refresh_from_db()
-        assert comment.is_deleted is True
-        assert comment.content == ""
-        assert comment.mentioned_emails == []
-        comment.delete()
+        # sole author in thread => hard-delete
+        assert not Comment.objects.filter(id=comment_id).exists()
 
     def test_delete_other_forbidden(self, orguser, other_orguser, snapshot, org):
         comment = Comment.objects.create(

--- a/ddpui/tests/core/reports/test_comment_service_mutations.py
+++ b/ddpui/tests/core/reports/test_comment_service_mutations.py
@@ -209,7 +209,8 @@ class TestUpdateComment:
 class TestDeleteComment:
     """Tests for CommentService.delete_comment"""
 
-    def test_success(self, snapshot, author_orguser, org):
+    def test_hard_deletes_sole_comment(self, snapshot, author_orguser, org):
+        """Only comment in thread, only author — hard-delete."""
         comment = Comment.objects.create(
             target_type=CommentTargetType.SUMMARY,
             snapshot=snapshot,
@@ -218,16 +219,67 @@ class TestDeleteComment:
             author=author_orguser,
             org=org,
         )
+        comment_id = comment.id
         CommentService.delete_comment(
-            comment_id=comment.id,
+            comment_id=comment_id,
             org=org,
             orguser=author_orguser,
         )
-        comment.refresh_from_db()
-        assert comment.is_deleted is True
-        assert comment.content == ""
-        assert comment.mentioned_emails == []
-        comment.delete()
+        assert not Comment.objects.filter(id=comment_id).exists()
+
+    def test_hard_deletes_multiple_own_comments(self, snapshot, author_orguser, org):
+        """Multiple comments in thread but ALL by the same author — hard-delete."""
+        c1 = Comment.objects.create(
+            target_type=CommentTargetType.SUMMARY,
+            snapshot=snapshot,
+            content="My first",
+            author=author_orguser,
+            org=org,
+        )
+        c2 = Comment.objects.create(
+            target_type=CommentTargetType.SUMMARY,
+            snapshot=snapshot,
+            content="My second",
+            author=author_orguser,
+            org=org,
+        )
+        c2_id = c2.id
+        CommentService.delete_comment(
+            comment_id=c2_id,
+            org=org,
+            orguser=author_orguser,
+        )
+        assert not Comment.objects.filter(id=c2_id).exists()
+        c1.delete()
+
+    def test_soft_deletes_when_other_author_exists(
+        self, snapshot, author_orguser, other_orguser, org
+    ):
+        """Another user has commented in the thread — soft-delete."""
+        Comment.objects.create(
+            target_type=CommentTargetType.SUMMARY,
+            snapshot=snapshot,
+            content="Other person's comment",
+            author=other_orguser,
+            org=org,
+        )
+        my_comment = Comment.objects.create(
+            target_type=CommentTargetType.SUMMARY,
+            snapshot=snapshot,
+            content="Delete me",
+            mentioned_emails=["someone@test.com"],
+            author=author_orguser,
+            org=org,
+        )
+        CommentService.delete_comment(
+            comment_id=my_comment.id,
+            org=org,
+            orguser=author_orguser,
+        )
+        my_comment.refresh_from_db()
+        assert my_comment.is_deleted is True
+        assert my_comment.content == ""
+        assert my_comment.mentioned_emails == []
 
     def test_non_author_raises(self, snapshot, author_orguser, other_orguser, org):
         comment = Comment.objects.create(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Comment deletion now hard-deletes only when the deleting author is the sole contributor in a thread; otherwise the comment remains in the thread but is cleared and marked deleted to preserve context.

* **Tests**
  * Added tests covering both hard-delete and soft-delete scenarios and asserting the resulting database state.

* **Documentation**
  * Updated in-code description of the deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->