### PR TITLE
fix: map chart with COUNT metric not rendering in downloaded PDF report

### DIFF
--- a/ddpui/api/public_api.py
+++ b/ddpui/api/public_api.py
@@ -664,7 +664,7 @@ def get_public_map_data_overlay(request, token: str, chart_id: int):
             orig_agg = original_metrics[0]["aggregation"]
             # For count without a column, fall back to geographic_column.
             # Mirrors the useMapDataOverlay hook's COUNT fallback in the frontend.
-            if orig_col is None and orig_agg == "count":
+            if orig_col is None and orig_agg and str(orig_agg).lower() == "count":
                 orig_col = payload.get("geographic_column")
                 payload["value_column"] = orig_col
             payload["metrics"] = [
@@ -681,7 +681,7 @@ def get_public_map_data_overlay(request, token: str, chart_id: int):
             geographic_col = payload.get("geographic_column")
             # For count without a column, fall back to geographic_column.
             # Mirrors the useMapDataOverlay hook's COUNT fallback in the frontend.
-            if not value_col and agg_function == "count" and geographic_col:
+            if not value_col and str(agg_function).lower() == "count" and geographic_col:
                 value_col = geographic_col
                 payload["value_column"] = geographic_col
             payload["metrics"] = [
@@ -1314,7 +1314,7 @@ def get_public_report_map_data(request, token: str):
             geographic_col = payload.get("geographic_column")
             # For count without a column, fall back to geographic_column.
             # Mirrors the useMapDataOverlay hook's COUNT fallback in the frontend.
-            if not value_col and agg_function == "count" and geographic_col:
+            if not value_col and str(agg_function).lower() == "count" and geographic_col:
                 value_col = geographic_col
                 payload["value_column"] = geographic_col
             if value_col:

--- a/ddpui/api/public_api.py
+++ b/ddpui/api/public_api.py
@@ -660,19 +660,34 @@ def get_public_map_data_overlay(request, token: str, chart_id: int):
         if "metrics" not in payload and chart.extra_config.get("metrics"):
             # Transform metrics to use 'value' alias (same as private API)
             original_metrics = chart.extra_config["metrics"]
+            orig_col = original_metrics[0]["column"]
+            orig_agg = original_metrics[0]["aggregation"]
+            # For count without a column, fall back to geographic_column.
+            # Mirrors the useMapDataOverlay hook's COUNT fallback in the frontend.
+            if orig_col is None and orig_agg == "count":
+                orig_col = payload.get("geographic_column")
+                payload["value_column"] = orig_col
             payload["metrics"] = [
                 {
-                    "column": original_metrics[0]["column"],
-                    "aggregation": original_metrics[0]["aggregation"],
+                    "column": orig_col,
+                    "aggregation": orig_agg,
                     "alias": "value",  # Force alias to 'value' like private API
                 }
             ]
         elif "metrics" not in payload:
             # Fallback: create a metric from value_column and aggregate_function
+            agg_function = payload.get("aggregate_function", "sum")
+            value_col = payload.get("value_column")
+            geographic_col = payload.get("geographic_column")
+            # For count without a column, fall back to geographic_column.
+            # Mirrors the useMapDataOverlay hook's COUNT fallback in the frontend.
+            if not value_col and agg_function == "count" and geographic_col:
+                value_col = geographic_col
+                payload["value_column"] = geographic_col
             payload["metrics"] = [
                 {
-                    "column": payload.get("value_column"),
-                    "aggregation": payload.get("aggregate_function", "sum"),
+                    "column": value_col,
+                    "aggregation": agg_function,
                     "alias": "value",  # Force alias to 'value' like private API
                 }
             ]
@@ -1293,14 +1308,23 @@ def get_public_report_map_data(request, token: str):
         payload = json.loads(request.body) if request.body else {}
 
         # Add metrics from payload if not provided (same logic as dashboard map endpoint)
-        if "metrics" not in payload and payload.get("value_column"):
-            payload["metrics"] = [
-                {
-                    "column": payload.get("value_column"),
-                    "aggregation": payload.get("aggregate_function", "sum"),
-                    "alias": "value",
-                }
-            ]
+        if "metrics" not in payload:
+            agg_function = payload.get("aggregate_function", "sum")
+            value_col = payload.get("value_column")
+            geographic_col = payload.get("geographic_column")
+            # For count without a column, fall back to geographic_column.
+            # Mirrors the useMapDataOverlay hook's COUNT fallback in the frontend.
+            if not value_col and agg_function == "count" and geographic_col:
+                value_col = geographic_col
+                payload["value_column"] = geographic_col
+            if value_col:
+                payload["metrics"] = [
+                    {
+                        "column": value_col,
+                        "aggregation": agg_function,
+                        "alias": "value",
+                    }
+                ]
 
         map_payload = MapDataOverlayPayload(**payload)
 

--- a/ddpui/tests/api_tests/test_public_report_api.py
+++ b/ddpui/tests/api_tests/test_public_report_api.py
@@ -465,11 +465,15 @@ class TestGetPublicReportMapData:
         """COUNT with null value_column substitutes geographic_column into metrics"""
         captured = {}
 
+        def build_chart_query_side_effect(p, _):
+            captured.update({"metrics": p.metrics})
+            raise Exception("stop")
+
         with patch("ddpui.api.public_api.OrgWarehouse.objects") as mock_ow, patch(
             "ddpui.api.public_api.WarehouseFactory.get_warehouse_client"
         ), patch(
             "ddpui.api.public_api.charts_service.build_chart_query",
-            side_effect=lambda p, _: captured.update({"metrics": p.metrics}) or (_ for _ in ()).throw(Exception("stop")),
+            side_effect=build_chart_query_side_effect,
         ):
             mock_ow.filter.return_value.first.return_value = MagicMock()
             request = _make_public_request(
@@ -543,11 +547,15 @@ class TestGetPublicMapDataOverlay:
         """COUNT with null column in chart.extra_config falls back to geographic_column"""
         captured = {}
 
+        def build_chart_query_side_effect(p, _):
+            captured.update({"metrics": p.metrics})
+            raise Exception("stop")
+
         with patch("ddpui.api.public_api.OrgWarehouse.objects") as mock_ow, patch(
             "ddpui.api.public_api.WarehouseFactory.get_warehouse_client"
         ), patch(
             "ddpui.api.public_api.charts_service.build_chart_query",
-            side_effect=lambda p, _: captured.update({"metrics": p.metrics}) or (_ for _ in ()).throw(Exception("stop")),
+            side_effect=build_chart_query_side_effect,
         ):
             mock_ow.filter.return_value.first.return_value = MagicMock()
             request = _make_public_request(

--- a/ddpui/tests/api_tests/test_public_report_api.py
+++ b/ddpui/tests/api_tests/test_public_report_api.py
@@ -38,6 +38,7 @@ from ddpui.api.public_api import (
     get_public_report_map_data,
     get_public_filter_preview,
     get_public_report_filter_preview,
+    get_public_map_data_overlay,
 )
 from ddpui.tests.api_tests.test_user_org_api import seed_db
 
@@ -459,6 +460,111 @@ class TestGetPublicReportMapData:
 
             assert status == 404
             assert response.is_valid is False
+
+    def test_count_metric_falls_back_to_geographic_column(self, public_snapshot, seed_db):
+        """COUNT with null value_column substitutes geographic_column into metrics"""
+        captured = {}
+
+        with patch("ddpui.api.public_api.OrgWarehouse.objects") as mock_ow, patch(
+            "ddpui.api.public_api.WarehouseFactory.get_warehouse_client"
+        ), patch(
+            "ddpui.api.public_api.charts_service.build_chart_query",
+            side_effect=lambda p, _: captured.update({"metrics": p.metrics}) or (_ for _ in ()).throw(Exception("stop")),
+        ):
+            mock_ow.filter.return_value.first.return_value = MagicMock()
+            request = _make_public_request(
+                body={
+                    "schema_name": "public",
+                    "table_name": "state_population",
+                    "geographic_column": "State",
+                    "value_column": None,
+                    "aggregate_function": "count",
+                }
+            )
+            get_public_report_map_data(request, public_snapshot.public_share_token)
+
+        assert captured["metrics"][0].column == "State"
+        assert captured["metrics"][0].aggregation == "count"
+
+
+# ================================================================================
+# Test get_public_map_data_overlay — COUNT fallback fix
+# ================================================================================
+
+
+@pytest.fixture
+def public_map_dashboard(orguser, org):
+    import uuid
+    dashboard = Dashboard.objects.create(
+        title="Public Map Dashboard",
+        description="Test",
+        dashboard_type="native",
+        grid_columns=12,
+        layout_config=[],
+        components={},
+        created_by=orguser,
+        org=org,
+        is_public=True,
+        public_share_token=str(uuid.uuid4()),
+    )
+    yield dashboard
+    try:
+        dashboard.refresh_from_db()
+        dashboard.delete()
+    except Dashboard.DoesNotExist:
+        pass
+
+
+@pytest.fixture
+def map_chart_count(orguser, org):
+    chart = Chart.objects.create(
+        title="Map Count Chart",
+        chart_type="map",
+        schema_name="public",
+        table_name="state_population",
+        extra_config={"metrics": [{"column": None, "aggregation": "count", "alias": "value"}]},
+        created_by=orguser,
+        org=org,
+    )
+    yield chart
+    try:
+        chart.refresh_from_db()
+        chart.delete()
+    except Chart.DoesNotExist:
+        pass
+
+
+class TestGetPublicMapDataOverlay:
+    """Tests for COUNT fallback fix in get_public_map_data_overlay"""
+
+    def test_count_metric_from_extra_config_uses_geographic_column(
+        self, public_map_dashboard, map_chart_count, seed_db
+    ):
+        """COUNT with null column in chart.extra_config falls back to geographic_column"""
+        captured = {}
+
+        with patch("ddpui.api.public_api.OrgWarehouse.objects") as mock_ow, patch(
+            "ddpui.api.public_api.WarehouseFactory.get_warehouse_client"
+        ), patch(
+            "ddpui.api.public_api.charts_service.build_chart_query",
+            side_effect=lambda p, _: captured.update({"metrics": p.metrics}) or (_ for _ in ()).throw(Exception("stop")),
+        ):
+            mock_ow.filter.return_value.first.return_value = MagicMock()
+            request = _make_public_request(
+                body={
+                    "schema_name": "public",
+                    "table_name": "state_population",
+                    "geographic_column": "State",
+                    "value_column": None,
+                    "aggregate_function": "count",
+                }
+            )
+            get_public_map_data_overlay(
+                request, public_map_dashboard.public_share_token, map_chart_count.id
+            )
+
+        assert captured["metrics"][0].column == "State"
+        assert captured["metrics"][0].aggregation == "count"
 
 
 # ================================================================================


### PR DESCRIPTION
## Bug
Map charts using COUNT as the metric were not loading in two places:
1. When a report was downloaded as a PDF
2. When a dashboard was shared via a public link and viewed by anyone
   without logging in

Charts using SUM or other metrics worked fine in both cases.

## Root Cause
When a report PDF is generated or a dashboard is viewed via a public share 
link, the backend uses a different code path than the normal browser view 
for logged-in users. In the normal browser view, there is existing logic 
that handles COUNT metric specially — since COUNT does not need a specific 
data column, it automatically uses the map's location column (e.g. "State", 
"District") to count records per location.

This special handling was missing in the two public API endpoints used 
during PDF generation and public share link rendering. So when COUNT was 
used, the column value was null and the query had nothing to count — 
causing the map to fail silently.

## Fix
Added the same COUNT fallback logic to both public API endpoints:
- `/reports/{token}/map-data/` — used when generating the PDF
- `/dashboards/{token}/charts/{id}/map-data/` — used for public share links

When COUNT is selected and no data column is provided, the map's location 
column is now used automatically — which gives the correct count of records 
per location (e.g. how many records exist per state).

This matches the existing logic that was already working correctly for 
logged-in users viewing the dashboard normally.

## Tests
Added 2 test cases covering the COUNT fallback in both endpoints to ensure 
this does not regress in the future.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map/report metric handling: when a count aggregation lacks a configured value column, the system now falls back to the geographic column so map overlays and public reports compute correctly.

* **Tests**
  * Added tests verifying the count-aggregation fallback behavior for map overlays and public report map data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->