### PR TITLE
Update filtering logic to handle `read_status=0` correctly using `read_status is not None`

### DIFF
--- a/ddpui/api/notifications_api.py
+++ b/ddpui/api/notifications_api.py
@@ -46,7 +46,7 @@ def get_notification_history(request, page: int = 1, limit: int = 10, read_statu
     Returns all the notifications including the
     past and the future scheduled notifications
     """
-    error, result = notifications_functions.get_notification_history(page, limit, read_status=None)
+    error, result = notifications_functions.get_notification_history(page, limit, read_status=read_status)
     if error is not None:
         raise HttpError(400, error)
 

--- a/ddpui/api/notifications_api.py
+++ b/ddpui/api/notifications_api.py
@@ -46,6 +46,9 @@ def get_notification_history(request, page: int = 1, limit: int = 10, read_statu
     Returns all the notifications including the
     past and the future scheduled notifications
     """
+    if read_status is not None and read_status not in (0, 1):
+        raise HttpError(400, "read_status must be 0 or 1")
+
     error, result = notifications_functions.get_notification_history(page, limit, read_status=read_status)
     if error is not None:
         raise HttpError(400, error)

--- a/ddpui/core/notifications/notifications_functions.py
+++ b/ddpui/core/notifications/notifications_functions.py
@@ -176,8 +176,10 @@ def get_notification_history(
     """returns history of sent notifications"""
     notifications = Notification.objects
 
-    if read_status:
-        notifications = notifications.filter(read_status=(read_status == 1))
+    if read_status is not None:
+        notifications = notifications.filter(
+            notifications_received__read_status=(read_status == 1)
+        ).distinct()
 
     notifications = notifications.all().order_by("-timestamp")
 


### PR DESCRIPTION
## Summary

Fixes #1309 by correctly applying the `read_status` query parameter in `/notifications/history`.

## Changes Made

* Forward incoming `read_status` from the API handler to `get_notification_history()`
* Update filtering logic to use `read_status is not None`

## Why

Previously:

* API route always passed `None`, so filtering was ignored
* `if read_status:` skipped filtering when `read_status=0`

## Result

* `read_status=1` returns read notifications
* `read_status=0` returns unread notifications
* no parameter returns all notifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request validation added for the read/unread filter: only 0 or 1 are accepted; invalid values return a 400 error.
  * Notification history filtering now respects falsey values (e.g., unread), and returns de-duplicated results so users see accurate, non-repeated notification lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->