### PR TITLE
Add TTL to email verification Redis tokens

### DIFF
--- a/ddpui/core/orguserfunctions.py
+++ b/ddpui/core/orguserfunctions.py
@@ -136,6 +136,7 @@ def signup_orguser(payload: OrgUserCreate):
     orguserid_bytes = str(orguser.id).encode("utf8")
 
     redis.set(redis_key, orguserid_bytes)
+    redis.expire(redis_key, 3600 * 24)  # 24 hours
 
     FRONTEND_URL = os.getenv("FRONTEND_URL")
     reset_url = f"{FRONTEND_URL}/verifyemail/?token={token.hex}"
@@ -450,6 +451,7 @@ def resend_verification_email(orguser: OrgUser, email: str):
     orguserid_bytes = str(orguser.id).encode("utf8")
 
     redis.set(redis_key, orguserid_bytes)
+    redis.expire(redis_key, 3600 * 24)  # 24 hours
 
     FRONTEND_URL = os.getenv("FRONTEND_URL")
     reset_url = f"{FRONTEND_URL}/verifyemail/?token={token.hex}"


### PR DESCRIPTION
  Summary

Fixes #1314.

Email verification tokens were stored in Redis without expiration, while password reset tokens already use a 24-hour TTL.

This updates the signup and resend verification flows to apply the same expiration time.

## Changes

* Added TTL for signup email verification tokens
* Added TTL for resend verification tokens

## Why

Keeps token lifecycle behavior consistent and helps prevent stale verification tokens from remaining indefinitely.

## Validation

* Verified updated code paths locally
* `python3 -m py_compile ddpui/core/orguserfunctions.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email verification tokens now automatically expire after 24 hours, ensuring they cannot be used indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->