### PR TITLE
fix(auth): return 403 instead of 404 in has_permission decorator

### DIFF
--- a/ddpui/auth.py
+++ b/ddpui/auth.py
@@ -31,18 +31,15 @@ def has_permission(permission_slugs: list):
     def decorator(api_endpoint):
         @wraps(api_endpoint)
         def wrapper(*args, **kwargs):
-            # request will have set of permissions that are allowed
-            # check if permission_slug lies in this set
-            # throw error if nots
             request = args[0]
-            try:
-                if not request.permissions or len(request.permissions) == 0:
-                    raise HttpError(403, "not allowed")
 
-                if not set(request.permissions).issuperset(set(permission_slugs)):
-                    raise HttpError(403, "not allowed")
-            except:
-                raise HttpError(404, UNAUTHORIZED)
+            permissions = getattr(request, "permissions", None)
+
+            if permissions is None or len(permissions) == 0:
+                raise HttpError(403, "not allowed")
+
+            if not set(permissions).issuperset(set(permission_slugs)):
+                raise HttpError(403, "not allowed")
 
             return api_endpoint(*args, **kwargs)
 


### PR DESCRIPTION
## Summary

Fix incorrect error handling in `has_permission` decorator.

The current implementation uses a bare `except:` block that catches `HttpError(403)` and re-raises it as `HttpError(404)`, causing permission-denied responses to incorrectly return 404 instead of 403.

## Changes

* Removed bare `except` block
* Explicitly handle missing or empty `request.permissions`
* Ensure permission failures return correct `403` status
* Allow unexpected errors to propagate

## Why

Returning 404 for authorization failures violates HTTP semantics and makes debugging harder. This change ensures accurate status codes and avoids masking real issues.

## Impact

* Correct API behavior for authorization failures
* Improved debugging clarity
* Aligns with standard HTTP semantics

Fixes #1325
