### PR TITLE
 Add type annotations to Airbyte API, service, and schema

### DIFF
--- a/ddpui/api/airbyte_api.py
+++ b/ddpui/api/airbyte_api.py
@@ -8,19 +8,33 @@ from ninja import Router
 from ddpui import settings
 from ddpui.ddpairbyte import airbyte_service
 from ddpui.ddpairbyte.schema import (
+    AirbyteCheckConnectionResponse,
+    AirbyteCancelJobResponse,
     AirbyteConnectionCreate,
     AirbyteConnectionCreateResponse,
-    AirbyteGetConnectionsResponse,
     AirbyteConnectionSchemaUpdateSchedule,
+    AirbyteConnectionUpdate,
     AirbyteDestinationCreate,
+    AirbyteDestinationDefinition,
+    AirbyteDestinationIdResponse,
+    AirbyteDestinationRead,
     AirbyteDestinationUpdate,
+    AirbyteDestinationUpdateCheckConnection,
+    AirbyteGetConnectionsResponse,
+    AirbyteJobStatusResponse,
+    AirbyteJobStatusWithoutLogsResponse,
+    AirbyteSchemaChangeResponse,
     AirbyteSourceCreate,
+    AirbyteSourceDefinition,
+    AirbyteSourceIdResponse,
+    AirbyteSourceRead,
     AirbyteSourceUpdate,
+    AirbyteSourceUpdateCheckConnection,
+    AirbyteSyncHistoryResponse,
+    AirbyteSuccessResponse,
+    AirbyteTaskResponse,
     AirbyteWorkspace,
     AirbyteWorkspaceCreate,
-    AirbyteSourceUpdateCheckConnection,
-    AirbyteDestinationUpdateCheckConnection,
-    AirbyteConnectionUpdate,
 )
 from ddpui.auth import has_permission
 
@@ -44,7 +58,7 @@ airbyte_router = Router()
 logger = CustomLogger("airbyte")
 
 
-@airbyte_router.get("/source_definitions")
+@airbyte_router.get("/source_definitions", response=List[AirbyteSourceDefinition])
 @has_permission(["can_view_sources"])
 def get_airbyte_source_definitions(request):
     """Fetch airbyte source definitions in the user organization workspace"""
@@ -66,7 +80,7 @@ def get_airbyte_source_definitions(request):
     return res["sourceDefinitions"]
 
 
-@airbyte_router.get("/source_definitions/{sourcedef_id}/specifications")
+@airbyte_router.get("/source_definitions/{sourcedef_id}/specifications", response=dict)
 @has_permission(["can_view_sources"])
 def get_airbyte_source_definition_specifications(request, sourcedef_id):
     """
@@ -84,7 +98,7 @@ def get_airbyte_source_definition_specifications(request, sourcedef_id):
     return res["connectionSpecification"]
 
 
-@airbyte_router.post("/sources/")
+@airbyte_router.post("/sources/", response=AirbyteSourceIdResponse)
 @has_permission(["can_create_source"])
 def post_airbyte_source(request, payload: AirbyteSourceCreate):
     """Create airbyte source in the user organization workspace"""
@@ -117,7 +131,7 @@ def post_airbyte_source(request, payload: AirbyteSourceCreate):
     return {"sourceId": source["sourceId"]}
 
 
-@airbyte_router.put("/sources/{source_id}")
+@airbyte_router.put("/sources/{source_id}", response=AirbyteSourceIdResponse)
 @has_permission(["can_edit_source"])
 def put_airbyte_source(request, source_id: str, payload: AirbyteSourceUpdate):
     """Update airbyte source in the user organization workspace"""
@@ -148,7 +162,7 @@ def put_airbyte_source(request, source_id: str, payload: AirbyteSourceUpdate):
     return {"sourceId": source["sourceId"]}
 
 
-@airbyte_router.post("/sources/check_connection/")
+@airbyte_router.post("/sources/check_connection/", response=AirbyteCheckConnectionResponse)
 @has_permission(["can_create_source"])
 def post_airbyte_check_source(request, payload: AirbyteSourceCreate):
     """Test the source connection in the user organization workspace"""
@@ -178,7 +192,9 @@ def post_airbyte_check_source(request, payload: AirbyteSourceCreate):
     }
 
 
-@airbyte_router.post("/sources/{source_id}/check_connection_for_update/")
+@airbyte_router.post(
+    "/sources/{source_id}/check_connection_for_update/", response=AirbyteCheckConnectionResponse
+)
 @has_permission(["can_edit_source"])
 def post_airbyte_check_source_for_update(
     request, source_id: str, payload: AirbyteSourceUpdateCheckConnection
@@ -209,7 +225,7 @@ def post_airbyte_check_source_for_update(
     }
 
 
-@airbyte_router.get("/sources")
+@airbyte_router.get("/sources", response=List[AirbyteSourceRead])
 @has_permission(["can_view_sources"])
 def get_airbyte_sources(request):
     """Fetch all airbyte sources in the user organization workspace"""
@@ -222,7 +238,7 @@ def get_airbyte_sources(request):
     return res
 
 
-@airbyte_router.get("/sources/{source_id}")
+@airbyte_router.get("/sources/{source_id}", response=AirbyteSourceRead)
 @has_permission(["can_view_source"])
 def get_airbyte_source(request, source_id):
     """Fetch a single airbyte source in the user organization workspace"""
@@ -235,7 +251,7 @@ def get_airbyte_source(request, source_id):
     return res
 
 
-@airbyte_router.get("/sources/{source_id}/schema_catalog")
+@airbyte_router.get("/sources/{source_id}/schema_catalog", response=dict)
 @has_permission(["can_view_source"])
 def get_airbyte_source_schema_catalog(request, source_id):
     """Fetch schema catalog for a source in the user organization workspace"""
@@ -248,7 +264,7 @@ def get_airbyte_source_schema_catalog(request, source_id):
     return res
 
 
-@airbyte_router.get("/destination_definitions")
+@airbyte_router.get("/destination_definitions", response=List[AirbyteDestinationDefinition])
 @has_permission(["can_view_warehouses"])
 def get_airbyte_destination_definitions(request):
     """Fetch destination definitions in the user organization workspace"""
@@ -266,7 +282,7 @@ def get_airbyte_destination_definitions(request):
     return res
 
 
-@airbyte_router.get("/destination_definitions/{destinationdef_id}/specifications")
+@airbyte_router.get("/destination_definitions/{destinationdef_id}/specifications", response=dict)
 @has_permission(["can_view_warehouse"])
 def get_airbyte_destination_definition_specifications(request, destinationdef_id):
     """
@@ -284,7 +300,7 @@ def get_airbyte_destination_definition_specifications(request, destinationdef_id
     return res
 
 
-@airbyte_router.post("/destinations/")
+@airbyte_router.post("/destinations/", response=AirbyteDestinationIdResponse)
 @has_permission(["can_create_warehouse"])
 def post_airbyte_destination(request, payload: AirbyteDestinationCreate):
     """Create an airbyte destination in the user organization workspace"""
@@ -302,7 +318,7 @@ def post_airbyte_destination(request, payload: AirbyteDestinationCreate):
     return {"destinationId": destination["destinationId"]}
 
 
-@airbyte_router.post("/destinations/check_connection/")
+@airbyte_router.post("/destinations/check_connection/", response=AirbyteCheckConnectionResponse)
 @has_permission(["can_create_warehouse"])
 def post_airbyte_check_destination(request, payload: AirbyteDestinationCreate):
     """Test connection to destination in the user organization workspace"""
@@ -319,7 +335,10 @@ def post_airbyte_check_destination(request, payload: AirbyteDestinationCreate):
     }
 
 
-@airbyte_router.post("/destinations/{destination_id}/check_connection_for_update/")
+@airbyte_router.post(
+    "/destinations/{destination_id}/check_connection_for_update/",
+    response=AirbyteCheckConnectionResponse,
+)
 @has_permission(["can_edit_warehouse"])
 def post_airbyte_check_destination_for_update(
     request, destination_id: str, payload: AirbyteDestinationUpdateCheckConnection
@@ -336,7 +355,7 @@ def post_airbyte_check_destination_for_update(
     }
 
 
-@airbyte_router.get("/destinations")
+@airbyte_router.get("/destinations", response=List[AirbyteDestinationRead])
 @has_permission(["can_view_warehouses"])
 def get_airbyte_destinations(request):
     """Fetch all airbyte destinations in the user organization workspace"""
@@ -349,7 +368,7 @@ def get_airbyte_destinations(request):
     return res
 
 
-@airbyte_router.get("/destinations/{destination_id}")
+@airbyte_router.get("/destinations/{destination_id}", response=AirbyteDestinationRead)
 @has_permission(["can_view_warehouse"])
 def get_airbyte_destination(request, destination_id):
     """Fetch an airbyte destination in the user organization workspace"""
@@ -362,7 +381,7 @@ def get_airbyte_destination(request, destination_id):
     return res
 
 
-@airbyte_router.get("/destinations/{destination_id}/specifications")
+@airbyte_router.get("/destinations/{destination_id}/specifications", response=dict)
 @has_permission(["can_view_warehouse"])
 def get_airbyte_destination_specifications_for_destination(request, destination_id):
     """
@@ -377,7 +396,7 @@ def get_airbyte_destination_specifications_for_destination(request, destination_
     return res
 
 
-@airbyte_router.get("/jobs/{job_id}")
+@airbyte_router.get("/jobs/{job_id}", response=AirbyteJobStatusResponse)
 @has_permission(["can_view_connection"])
 def get_job_status(request, job_id):
     """get the job info from airbyte"""
@@ -389,7 +408,7 @@ def get_job_status(request, job_id):
     }
 
 
-@airbyte_router.get("/jobs/{job_id}/status")
+@airbyte_router.get("/jobs/{job_id}/status", response=AirbyteJobStatusWithoutLogsResponse)
 @has_permission(["can_view_connection"])
 def get_job_status_without_logs(request, job_id):
     """get the job info from airbyte"""
@@ -481,7 +500,7 @@ def get_airbyte_connection_v1(request, connection_id):
     return res
 
 
-@airbyte_router.put("/v1/connections/{connection_id}/update")
+@airbyte_router.put("/v1/connections/{connection_id}/update", response=dict)
 @has_permission(["can_edit_connection"])
 def put_airbyte_connection_v1(
     request, connection_id, payload: AirbyteConnectionUpdate
@@ -499,7 +518,7 @@ def put_airbyte_connection_v1(
     return res
 
 
-@airbyte_router.delete("/v1/connections/{connection_id}")
+@airbyte_router.delete("/v1/connections/{connection_id}", response=AirbyteSuccessResponse)
 @has_permission(["can_delete_connection"])
 def delete_airbyte_connection_v1(request, connection_id):
     """Update an airbyte connection in the user organization workspace"""
@@ -517,7 +536,7 @@ def delete_airbyte_connection_v1(request, connection_id):
     return {"success": 1}
 
 
-@airbyte_router.get("/v1/connections/{connection_id}/jobs")
+@airbyte_router.get("/v1/connections/{connection_id}/jobs", response=dict)
 @has_permission(["can_view_connection"])
 def get_latest_job_for_connection(request, connection_id):
     """get the job info from airbyte for a connection"""
@@ -532,7 +551,9 @@ def get_latest_job_for_connection(request, connection_id):
     return job_info
 
 
-@airbyte_router.get("/v1/connections/{connection_id}/sync/history")
+@airbyte_router.get(
+    "/v1/connections/{connection_id}/sync/history", response=AirbyteSyncHistoryResponse
+)
 @has_permission(["can_view_connection"])
 def get_sync_history_for_connection(request, connection_id, limit: int = 10, offset: int = 0):
     """get the job info from airbyte for a connection"""
@@ -549,7 +570,7 @@ def get_sync_history_for_connection(request, connection_id, limit: int = 10, off
     return job_info
 
 
-@airbyte_router.put("/v1/destinations/{destination_id}/")
+@airbyte_router.put("/v1/destinations/{destination_id}/", response=AirbyteDestinationIdResponse)
 @has_permission(["can_edit_warehouse"])
 def put_airbyte_destination_v1(request, destination_id: str, payload: AirbyteDestinationUpdate):
     """Update an airbyte destination in the user organization workspace"""
@@ -566,7 +587,7 @@ def put_airbyte_destination_v1(request, destination_id: str, payload: AirbyteDes
     return {"destinationId": destination["destinationId"]}
 
 
-@airbyte_router.delete("/sources/{source_id}")
+@airbyte_router.delete("/sources/{source_id}", response=AirbyteSuccessResponse)
 @has_permission(["can_delete_source"])
 def delete_airbyte_source_v1(request, source_id):
     """Delete a single airbyte source in the user organization workspace"""
@@ -583,7 +604,7 @@ def delete_airbyte_source_v1(request, source_id):
     return {"success": 1}
 
 
-@airbyte_router.get("/v1/connections/{connection_id}/catalog")
+@airbyte_router.get("/v1/connections/{connection_id}/catalog", response=AirbyteTaskResponse)
 @has_permission(["can_view_connection"])
 def get_connection_catalog_v1(request, connection_id):
     """Fetch a connection in the user organization workspace"""
@@ -609,7 +630,9 @@ def get_connection_catalog_v1(request, connection_id):
     return {"task_id": task_key}
 
 
-@airbyte_router.post("/v1/connections/{connection_id}/schema_update/schedule")
+@airbyte_router.post(
+    "/v1/connections/{connection_id}/schema_update/schedule", response=AirbyteSuccessResponse
+)
 @has_permission(["can_edit_connection"])
 def schedule_update_connection_schema(
     request, connection_id, payload: AirbyteConnectionSchemaUpdateSchedule
@@ -630,7 +653,7 @@ def schedule_update_connection_schema(
     return {"success": 1}
 
 
-@airbyte_router.get("/v1/connection/schema_change")
+@airbyte_router.get("/v1/connection/schema_change", response=List[AirbyteSchemaChangeResponse])
 @has_permission(["can_view_connection"])
 def get_schema_changes_for_connection(request):
     """Get schema changes for an org"""
@@ -645,7 +668,7 @@ def get_schema_changes_for_connection(request):
     return res
 
 
-@airbyte_router.get("/v1/connections/{connection_id}/logsummary")
+@airbyte_router.get("/v1/connections/{connection_id}/logsummary", response=AirbyteTaskResponse)
 @has_permission(["can_view_pipeline"])
 def get_flow_runs_logsummary_v1(
     request, connection_id: str, job_id: int, attempt_number: int, regenerate: int = 0
@@ -680,7 +703,7 @@ def get_flow_runs_logsummary_v1(
         raise HttpError(400, "failed to retrieve logs") from error
 
 
-@airbyte_router.get("/v1/logs")
+@airbyte_router.get("/v1/logs", response=List[str])
 @has_permission(["can_view_connection"])
 def get_job_logs(
     request,
@@ -697,7 +720,9 @@ def get_job_logs(
     return log_lines
 
 
-@airbyte_router.post("/v1/connections/{connection_id}/cancel/{job_type}/")
+@airbyte_router.post(
+    "/v1/connections/{connection_id}/cancel/{job_type}/", response=AirbyteCancelJobResponse
+)
 @has_permission(["can_edit_connection"])
 def post_cancel_connection_job(
     request,

--- a/ddpui/ddpairbyte/airbyte_service.py
+++ b/ddpui/ddpairbyte/airbyte_service.py
@@ -4,7 +4,7 @@ Functions which communicate with Airbyte
 These functions do not access the Dalgo database
 """
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 import os
 import json
 from datetime import datetime
@@ -86,7 +86,7 @@ def abreq(endpoint, req=None, **kwargs):
     return {}
 
 
-def get_workspaces():
+def get_workspaces() -> dict:
     """Fetch all workspaces in airbyte server"""
     logger.info("Fetching workspaces from Airbyte server")
 
@@ -139,7 +139,7 @@ def create_workspace(name: str) -> dict:
     return res
 
 
-def delete_workspace(workspace_id: str):
+def delete_workspace(workspace_id: str) -> dict:
     """Deletes an airbyte workspace"""
     res = abreq("workspaces/delete", {"workspaceId": workspace_id})
     return res
@@ -167,7 +167,7 @@ def get_source_definition(workspace_id: str, sourcedef_id: str) -> dict:
     return res
 
 
-def get_source_definitions(workspace_id: str) -> List[Dict]:
+def get_source_definitions(workspace_id: str) -> dict:
     """Fetch source definitions for an airbyte workspace"""
     if not isinstance(workspace_id, str):
         raise HttpError(400, "Invalid workspace ID")
@@ -228,7 +228,7 @@ def create_custom_source_definition(
     docker_repository: str,
     docker_image_tag: str,
     documentation_url: str,
-):
+) -> dict:
     """Create a custom source definition in Airbyte."""
     if not isinstance(workspace_id, str):
         raise HttpError(400, "Invalid workspace ID")
@@ -261,7 +261,7 @@ def create_custom_source_definition(
     return res
 
 
-def get_sources(workspace_id: str) -> List[Dict]:
+def get_sources(workspace_id: str) -> dict:
     """Fetch all sources in an airbyte workspace"""
     if not isinstance(workspace_id, str):
         raise HttpError(400, "Invalid workspace ID")
@@ -404,7 +404,9 @@ def check_source_connection(workspace_id: str, data: AirbyteSourceCreate) -> dic
     return res
 
 
-def check_source_connection_for_update(source_id: str, data: AirbyteSourceUpdateCheckConnection):
+def check_source_connection_for_update(
+    source_id: str, data: AirbyteSourceUpdateCheckConnection
+) -> dict:
     """Test connection on a potential edit on source"""
     res = abreq(
         "sources/check_connection_for_update",
@@ -661,7 +663,7 @@ def check_destination_connection(workspace_id: str, data: AirbyteDestinationCrea
 
 def check_destination_connection_for_update(
     destination_id: str, data: AirbyteDestinationUpdateCheckConnection
-):
+) -> dict:
     """Test a potential destination's connection in an airbyte workspace"""
     if not isinstance(destination_id, str):
         raise HttpError(400, "destination_id must be a string")
@@ -1005,7 +1007,7 @@ def get_jobs_for_connection(
     job_types: list[str] | None = None,
     created_at_start: datetime = None,
     created_at_end: datetime = None,
-) -> int | None:
+) -> dict:
     """
     returns most recent job for a connection
     possible configTypes are
@@ -1117,7 +1119,7 @@ def get_connection_catalog(connection_id: str, **kwargs) -> dict:
     return res
 
 
-def get_current_airbyte_version():
+def get_current_airbyte_version() -> Optional[str]:
     """Fetch airbyte version"""
 
     res = abreq("instance_configuration", method="GET")

--- a/ddpui/ddpairbyte/schema.py
+++ b/ddpui/ddpairbyte/schema.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from typing import Any, List, Optional
+from datetime import datetime
 from ninja import Schema
 from ddpui.ddpprefect.schema import DeploymentCurrentQueueTime
 
@@ -137,3 +138,137 @@ class AirbyteConnectionSchemaUpdateSchedule(Schema):
 
     catalogDiff: dict
     cron: Optional[str] = None
+
+
+# ============================================================
+# New response schemas
+# ============================================================
+
+
+class AirbyteSourceDefinition(Schema):
+    """Schema for an Airbyte source definition"""
+
+    sourceDefinitionId: str
+    name: str
+    dockerRepository: str
+    dockerImageTag: str
+    documentationUrl: Optional[str] = None
+    releaseStage: Optional[str] = None
+
+
+class AirbyteSourceRead(Schema):
+    """Schema for a single Airbyte source"""
+
+    sourceId: str
+    name: str
+    sourceName: str
+    sourceDefinitionId: str
+    workspaceId: str
+    connectionConfiguration: dict
+
+
+class AirbyteDestinationDefinition(Schema):
+    """Schema for an Airbyte destination definition"""
+
+    destinationDefinitionId: str
+    name: str
+    dockerRepository: str
+    dockerImageTag: str
+    documentationUrl: Optional[str] = None
+    releaseStage: Optional[str] = None
+
+
+class AirbyteDestinationRead(Schema):
+    """Schema for a single Airbyte destination"""
+
+    destinationId: str
+    name: str
+    destinationName: str
+    destinationDefinitionId: str
+    workspaceId: str
+    connectionConfiguration: dict
+
+
+class AirbyteSourceIdResponse(Schema):
+    """Schema for source create/update response"""
+
+    sourceId: str
+
+
+class AirbyteDestinationIdResponse(Schema):
+    """Schema for destination create/update response"""
+
+    destinationId: str
+
+
+class AirbyteCheckConnectionResponse(Schema):
+    """Schema for connection check response"""
+
+    status: str
+    logs: List[str]
+
+
+class AirbyteJobStatusResponse(Schema):
+    """Schema for job status response with logs"""
+
+    status: str
+    logs: List[str]
+
+
+class AirbyteJobStatusWithoutLogsResponse(Schema):
+    """Schema for job status response without logs"""
+
+    status: str
+
+
+class AirbyteSuccessResponse(Schema):
+    """Schema for simple success responses"""
+
+    success: int
+
+
+class AirbyteTaskResponse(Schema):
+    """Schema for async task responses"""
+
+    task_id: str
+    message: Optional[str] = None
+
+
+class AirbyteSyncHistoryItemResponse(Schema):
+    """Schema for a single sync history item"""
+
+    job_id: int
+    status: str
+    job_type: str
+    created_at: Optional[datetime] = None
+    started_at: Optional[datetime] = None
+    ended_at: Optional[datetime] = None
+    records_emitted: int = 0
+    bytes_emitted: Any = 0
+    records_committed: int = 0
+    bytes_committed: Any = 0
+    stream_stats: Optional[Any] = None
+    reset_config: Optional[Any] = None
+    duration_seconds: Optional[float] = None
+    last_attempt_no: Optional[int] = None
+
+
+class AirbyteSyncHistoryResponse(Schema):
+    """Schema for paginated sync history"""
+
+    history: List[AirbyteSyncHistoryItemResponse]
+    totalSyncs: int
+
+
+class AirbyteSchemaChangeResponse(Schema):
+    """Schema for a schema change entry"""
+
+    connection_id: str
+    change_type: str
+    schedule_job: Optional[Any] = None
+
+
+class AirbyteCancelJobResponse(Schema):
+    """Schema for cancel job response"""
+
+    cancelled: bool


### PR DESCRIPTION
Closes #1015

  ## Changes

  `ddpui/ddpairbyte/schema.py`
  Added 14 new response schemas:
  - `AirbyteSourceDefinition`, `AirbyteSourceRead`
  - `AirbyteDestinationDefinition`, `AirbyteDestinationRead`
  - `AirbyteSourceIdResponse`, `AirbyteDestinationIdResponse`
  - `AirbyteCheckConnectionResponse`
  - `AirbyteJobStatusResponse`, `AirbyteJobStatusWithoutLogsResponse`
  - `AirbyteSuccessResponse`, `AirbyteTaskResponse`
  - `AirbyteSyncHistoryItemResponse`, `AirbyteSyncHistoryResponse`
  - `AirbyteSchemaChangeResponse`, `AirbyteCancelJobResponse`

   `ddpui/api/airbyte_api.py`
  Added `response=` type annotations to all 31 previously untyped endpoints.

   `ddpui/ddpairbyte/airbyte_service.py`
  - Fixed incorrect return types: `get_source_definitions`, `get_sources` (`List[Dict]` → `dict`),
  `get_jobs_for_connection` (`int | None` → `dict`)
  - Added missing return types to: `get_workspaces`, `delete_workspace`, `create_custom_source_definition`,
   `check_source_connection_for_update`, `check_destination_connection_for_update`,
  `get_current_airbyte_version`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced type safety and consistency across Airbyte API endpoints by adding explicit response schemas and type annotations to routes and service functions.
  * Introduced comprehensive response classes for sources, destinations, connections, jobs, sync history, and schema changes to ensure structured and predictable API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->