### PR TITLE
Added pagination to the prefect logs

### DIFF
--- a/ddpui/api/pipeline_api.py
+++ b/ddpui/api/pipeline_api.py
@@ -233,6 +233,12 @@ def get_flow_runs_logs(
 ):  # pylint: disable=unused-argument
     """return the logs from a flow-run"""
     try:
+        if limit == 0:
+            all_logs = prefect_service.recurse_flow_run_logs(
+                flow_run_id, task_run_id or None, offset=offset
+            )
+            return {"logs": {"offset": offset, "logs": all_logs}}
+
         result = prefect_service.get_flow_run_logs(flow_run_id, task_run_id, limit, offset)
     except Exception as error:
         logger.exception(error)


### PR DESCRIPTION
issue was, that by default 0 limit and 0 offset were going in int he query params, so prefect was just sending the first 200 logs. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow run logs retrieval to handle specific parameter values more effectively.
  * Enhanced response format to include offset information in applicable scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->