### PR TITLE
fix(auth): return 403 (not 404) when has_permission denies access

### DIFF
--- a/ddpui/auth.py
+++ b/ddpui/auth.py
@@ -33,16 +33,13 @@ def has_permission(permission_slugs: list):
         def wrapper(*args, **kwargs):
             # request will have set of permissions that are allowed
             # check if permission_slug lies in this set
-            # throw error if nots
+            # throw 403 if not — bare except previously masked this as 404 (issue #1325)
             request = args[0]
-            try:
-                if not request.permissions or len(request.permissions) == 0:
-                    raise HttpError(403, "not allowed")
+            if not request.permissions or len(request.permissions) == 0:
+                raise HttpError(403, "not allowed")
 
-                if not set(request.permissions).issuperset(set(permission_slugs)):
-                    raise HttpError(403, "not allowed")
-            except:
-                raise HttpError(404, UNAUTHORIZED)
+            if not set(request.permissions).issuperset(set(permission_slugs)):
+                raise HttpError(403, "not allowed")
 
             return api_endpoint(*args, **kwargs)
 

--- a/ddpui/tests/core/test_has_permission.py
+++ b/ddpui/tests/core/test_has_permission.py
@@ -1,0 +1,61 @@
+"""Regression tests for the has_permission decorator (issue #1325).
+
+These tests verify that has_permission raises HTTP 403 (not 404) when the
+caller lacks the required permissions. A previous bare ``except`` block in
+the decorator masked 403 errors as 404, violating HTTP semantics.
+
+These tests do not touch the database, so they intentionally live outside
+test_auth.py (which is module-marked with pytest.mark.django_db).
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from ninja.errors import HttpError
+
+from ddpui.auth import has_permission
+
+
+def _make_request_with_permissions(permissions):
+    request = Mock()
+    request.permissions = permissions
+    return request
+
+
+def test_has_permission_raises_403_when_permissions_empty():
+    """Empty permissions list must raise 403, not 404."""
+
+    @has_permission(["can_view_charts"])
+    def endpoint(request):
+        return "ok"
+
+    request = _make_request_with_permissions([])
+    with pytest.raises(HttpError) as excinfo:
+        endpoint(request)
+    assert excinfo.value.status_code == 403
+    assert str(excinfo.value) == "not allowed"
+
+
+def test_has_permission_raises_403_when_required_slug_missing():
+    """Missing a required permission slug must raise 403, not 404."""
+
+    @has_permission(["can_edit_charts"])
+    def endpoint(request):
+        return "ok"
+
+    request = _make_request_with_permissions(["can_view_charts"])
+    with pytest.raises(HttpError) as excinfo:
+        endpoint(request)
+    assert excinfo.value.status_code == 403
+    assert str(excinfo.value) == "not allowed"
+
+
+def test_has_permission_allows_when_caller_has_required_permissions():
+    """Happy path: caller has the required slug, endpoint executes."""
+
+    @has_permission(["can_view_charts"])
+    def endpoint(request):
+        return "ok"
+
+    request = _make_request_with_permissions(["can_view_charts", "can_edit_charts"])
+    assert endpoint(request) == "ok"


### PR DESCRIPTION
A bare ``except`` in the has_permission decorator caught the 403 raised on permission failure and re-raised it as 404 UNAUTHORIZED. That violates HTTP semantics (404 = resource missing, 403 = forbidden) and obscures real authorization failures during debugging.

Remove the try/except so HttpError(403) propagates naturally. Add regression tests covering empty permissions, missing required slug, and the happy path. Tests live in their own file so they don't pull in the django_db marker from test_auth.py.

Fixes #1325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission error responses to return HTTP 403 (Forbidden) with "not allowed" message instead of HTTP 404 when required permissions are missing or insufficient.

* **Tests**
  * Added regression tests for the permission decorator to verify correct behavior for empty permissions, missing required permissions, and successful access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->