### PR TITLE
fix(security): scope invitation delete/resend by requestor's org (IDOR)

### DIFF
--- a/ddpui/api/user_org_api.py
+++ b/ddpui/api/user_org_api.py
@@ -509,7 +509,7 @@ def post_resend_invitation(request, invitation_id):
     if orguser.org is None:
         raise HttpError(400, "create an organization first")
 
-    _, error = orguserfunctions.resend_invitation(invitation_id)
+    _, error = orguserfunctions.resend_invitation(invitation_id, orguser.org)
     if error:
         raise HttpError(400, error)
 
@@ -524,7 +524,10 @@ def delete_invitation(request, invitation_id):
     if orguser.org is None:
         raise HttpError(400, "create an organization first")
 
-    invitation = Invitation.objects.filter(id=invitation_id).first()
+    # scope by org so a user cannot delete invitations belonging to another org
+    invitation = Invitation.objects.filter(
+        id=invitation_id, invited_by__org=orguser.org
+    ).first()
 
     if invitation:
         invitation.delete()

--- a/ddpui/core/orguserfunctions.py
+++ b/ddpui/core/orguserfunctions.py
@@ -360,9 +360,12 @@ def get_invitations_from_orguser_v1(orguser: OrgUser):
     return res, None
 
 
-def resend_invitation(invitation_id: str):
-    """resend email invitation to user"""
-    invitation = Invitation.objects.filter(id=invitation_id).first()
+def resend_invitation(invitation_id: str, org):
+    """resend email invitation to user — scoped to the requestor's org"""
+    # scope by org so a user cannot resend invitations belonging to another org
+    invitation = Invitation.objects.filter(
+        id=invitation_id, invited_by__org=org
+    ).first()
 
     if invitation:
         invitation.invited_on = timezone.as_utc(datetime.utcnow())

--- a/ddpui/tests/core/test_invitation_idor.py
+++ b/ddpui/tests/core/test_invitation_idor.py
@@ -1,0 +1,122 @@
+"""Regression tests for invitation cross-tenant IDOR.
+
+Before the fix, ``Invitation.objects.filter(id=invitation_id)`` was used
+without any org constraint in both:
+
+* ``ddpui.api.user_org_api.delete_invitation``
+* ``ddpui.core.orguserfunctions.resend_invitation``
+
+A user with ``can_delete_invitation`` / ``can_edit_invitation`` in *any*
+org could therefore guess an integer ``invitation_id`` and revoke or
+re-trigger an invitation belonging to a *different* tenant.
+
+These tests exercise the queryset call that the fix relies on: the
+filter must include ``invited_by__org=<requestor_org>``, and the lookup
+must miss when the invitation belongs to another org.
+"""
+
+from unittest.mock import Mock, patch
+
+from ddpui.api import user_org_api
+from ddpui.core import orguserfunctions
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _request_for(orguser):
+    """Build a Mock request that satisfies @has_permission and the endpoint body."""
+    request = Mock()
+    request.permissions = ["can_delete_invitation"]
+    request.orguser = orguser
+    return request
+
+
+# ---------------------------------------------------------------------------
+# delete_invitation (api layer)
+# ---------------------------------------------------------------------------
+
+
+@patch("ddpui.api.user_org_api.Invitation.objects.filter")
+def test_delete_invitation_filters_by_requestor_org(mock_filter):
+    """The filter must include invited_by__org so cross-tenant lookups miss."""
+    org_a = Mock(name="org_a")
+    orguser = Mock(org=org_a)
+
+    mock_filter.return_value.first.return_value = None  # cross-org lookup → not found
+
+    result = user_org_api.delete_invitation(_request_for(orguser), 42)
+
+    mock_filter.assert_called_once_with(id=42, invited_by__org=org_a)
+    assert result == {"success": 1}
+
+
+@patch("ddpui.api.user_org_api.Invitation.objects.filter")
+def test_delete_invitation_does_not_delete_other_orgs_invitation(mock_filter):
+    """If the lookup returns no row, .delete() must not be called."""
+    org_a = Mock(name="org_a")
+    orguser = Mock(org=org_a)
+
+    foreign_invitation = Mock()  # belongs to some other org — but filter excludes it
+    mock_filter.return_value.first.return_value = None  # filter excluded it
+
+    user_org_api.delete_invitation(_request_for(orguser), 999)
+
+    foreign_invitation.delete.assert_not_called()
+
+
+@patch("ddpui.api.user_org_api.Invitation.objects.filter")
+def test_delete_invitation_deletes_when_invitation_belongs_to_org(mock_filter):
+    """In-org delete still works."""
+    org_a = Mock(name="org_a")
+    orguser = Mock(org=org_a)
+
+    own_invitation = Mock()
+    mock_filter.return_value.first.return_value = own_invitation
+
+    result = user_org_api.delete_invitation(_request_for(orguser), 7)
+
+    mock_filter.assert_called_once_with(id=7, invited_by__org=org_a)
+    own_invitation.delete.assert_called_once()
+    assert result == {"success": 1}
+
+
+# ---------------------------------------------------------------------------
+# resend_invitation (core layer)
+# ---------------------------------------------------------------------------
+
+
+@patch("ddpui.core.orguserfunctions.awsses.send_invite_user_email")
+@patch("ddpui.core.orguserfunctions.Invitation.objects.filter")
+def test_resend_invitation_does_not_resend_other_orgs_invitation(
+    mock_filter, mock_send_email
+):
+    """A foreign-org invitation_id must not trigger an email."""
+    org_a = Mock(name="org_a")
+    mock_filter.return_value.first.return_value = None  # filtered out by org
+
+    result, error = orguserfunctions.resend_invitation("42", org_a)
+
+    mock_filter.assert_called_once_with(id="42", invited_by__org=org_a)
+    mock_send_email.assert_not_called()
+    assert result is None and error is None
+
+
+@patch("ddpui.core.orguserfunctions.awsses.send_invite_user_email")
+@patch("ddpui.core.orguserfunctions.Invitation.objects.filter")
+def test_resend_invitation_resends_when_invitation_belongs_to_org(
+    mock_filter, mock_send_email
+):
+    """In-org resend triggers the invitation email."""
+    org_a = Mock(name="org_a")
+    invitation = Mock(invite_code="abc", invited_email="invitee@example.com")
+    invitation.invited_by.user.email = "admin@example.com"
+    mock_filter.return_value.first.return_value = invitation
+
+    orguserfunctions.resend_invitation("7", org_a)
+
+    mock_filter.assert_called_once_with(id="7", invited_by__org=org_a)
+    invitation.save.assert_called_once()
+    mock_send_email.assert_called_once()


### PR DESCRIPTION
Both ``delete_invitation`` (api) and ``resend_invitation`` (core) looked up an Invitation by raw integer id with no org constraint:

    invitation = Invitation.objects.filter(id=invitation_id).first()

A user holding ``can_delete_invitation`` or ``can_edit_invitation`` in any org could iterate ids and revoke or re-trigger invitations belonging to other tenants. Both endpoints already require the user to have an org, but the lookup itself was unscoped.

Add ``invited_by__org=<requestor_org>`` to the filter in both call sites. ``resend_invitation`` now takes an explicit ``org`` argument which the API caller passes from ``request.orguser.org``.

Add 5 regression tests in ``test_invitation_idor.py`` that mock ``Invitation.objects.filter`` and assert (a) the filter is called with both ``id`` and ``invited_by__org``, (b) cross-org lookups don't trigger ``.delete()`` or the invitation email, and (c) in-org operations still succeed.