### PR TITLE
decouple DashboardFilterResponse from model.to_json 

### DIFF
--- a/ddpui/api/dashboard_native_api.py
+++ b/ddpui/api/dashboard_native_api.py
@@ -340,7 +340,7 @@ def create_filter(request, dashboard_id: int, payload: FilterCreate):
     except FilterValidationError as err:
         raise HttpError(400, err.message) from err
 
-    return DashboardFilterResponse(**filter_obj.to_json())
+    return DashboardFilterResponse.from_model(filter_obj)
 
 
 @dashboard_native_router.get(
@@ -358,7 +358,7 @@ def get_filter(request, dashboard_id: int, filter_id: int):
     except FilterNotFoundError as err:
         raise HttpError(404, "Filter not found") from err
 
-    return DashboardFilterResponse(**filter_obj.to_json())
+    return DashboardFilterResponse.from_model(filter_obj)
 
 
 @dashboard_native_router.put(
@@ -383,7 +383,7 @@ def update_filter(request, dashboard_id: int, filter_id: int, payload: FilterUpd
     except FilterValidationError as err:
         raise HttpError(400, err.message) from err
 
-    return DashboardFilterResponse(**filter_obj.to_json())
+    return DashboardFilterResponse.from_model(filter_obj)
 
 
 @dashboard_native_router.delete("/{dashboard_id}/filters/{filter_id}/")

--- a/ddpui/schemas/dashboard_schema.py
+++ b/ddpui/schemas/dashboard_schema.py
@@ -50,6 +50,23 @@ class DashboardFilterResponse(Schema):
     created_at: datetime
     updated_at: datetime
 
+    @classmethod
+    def from_model(cls, filter_obj) -> "DashboardFilterResponse":
+        """Build response from a DashboardFilter model instance."""
+        return cls(
+            id=filter_obj.id,
+            dashboard_id=filter_obj.dashboard_id,
+            name=filter_obj.name,
+            filter_type=filter_obj.filter_type,
+            schema_name=filter_obj.schema_name,
+            table_name=filter_obj.table_name,
+            column_name=filter_obj.column_name,
+            settings=filter_obj.settings,
+            order=filter_obj.order,
+            created_at=filter_obj.created_at,
+            updated_at=filter_obj.updated_at,
+        )
+
 
 class DashboardResponse(Schema):
     """Response schema for dashboard"""

--- a/ddpui/tests/schema_tests/test_dashboard_schema.py
+++ b/ddpui/tests/schema_tests/test_dashboard_schema.py
@@ -352,6 +352,39 @@ class TestEdgeCases:
         assert response.settings["range"]["min"] == 0
         assert response.settings["display"]["prefix"] == "$"
 
+    def test_filter_response_from_model(self):
+        """from_model() builds a response with the same fields as the source model instance."""
+        from types import SimpleNamespace
+
+        now = datetime.now()
+        filter_obj = SimpleNamespace(
+            id=42,
+            dashboard_id=7,
+            name="Region",
+            filter_type="value",
+            schema_name="public",
+            table_name="orders",
+            column_name="region",
+            settings={"options": ["NA", "EU"]},
+            order=2,
+            created_at=now,
+            updated_at=now,
+        )
+
+        response = DashboardFilterResponse.from_model(filter_obj)
+
+        assert response.id == 42
+        assert response.dashboard_id == 7
+        assert response.name == "Region"
+        assert response.filter_type == "value"
+        assert response.schema_name == "public"
+        assert response.table_name == "orders"
+        assert response.column_name == "region"
+        assert response.settings == {"options": ["NA", "EU"]}
+        assert response.order == 2
+        assert response.created_at == now
+        assert response.updated_at == now
+
     def test_dashboard_response_with_filters(self):
         """Test dashboard response with embedded filters"""
         now = datetime.now()


### PR DESCRIPTION
## Summary

Closes #1336.

Replaces `DashboardFilterResponse(**filter_obj.to_json())` in three filter endpoints with a new `DashboardFilterResponse.from_model()` classmethod, per the project's API design conventions in `.claude/CLAUDE.md` (schemas own model→response conversion; the API layer should not unpack model serialization output).

## Changes

- **`ddpui/schemas/dashboard_schema.py`** — added `DashboardFilterResponse.from_model()` classmethod.
- **`ddpui/api/dashboard_native_api.py`** — `create_filter`, `get_filter`, and `update_filter` now call `DashboardFilterResponse.from_model(filter_obj)`.
- **`ddpui/tests/schema_tests/test_dashboard_schema.py`** — added `test_filter_response_from_model` covering the new classmethod.

## Verification

Response wire format is unchanged — `DashboardFilterResponse` is the response type either way, so no frontend impact.

```bash
uv run pytest ddpui/tests/schema_tests/test_dashboard_schema.py -v
# 25 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced dashboard filter endpoints to use an improved method for constructing API responses during filter operations (create, read, update).

* **Tests**
  * Added test case validating proper field mapping when constructing dashboard filter responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DalgoT4D/DDP_backend/pull/1337)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->