### PR TITLE
UI4T: join on multiple keys (#975)

### DIFF
--- a/ddpui/core/dbt_automation/operations/joins.py
+++ b/ddpui/core/dbt_automation/operations/joins.py
@@ -105,11 +105,20 @@ def joins_sql(
         )
 
     join_conditions = join_on if isinstance(join_on, list) else [join_on]
+    if not join_conditions:
+        raise ValueError("Join operation requires at least one join condition")
+
     on_clause = []
+    allowed_operators = ["=", "!=", "<>", ">", "<", ">=", "<=", "LIKE", "ILIKE"]
+
     for condition in join_conditions:
+        op = condition["compare_with"].upper()
+        if op not in allowed_operators:
+            raise ValueError(f"Operator {op} not allowed in join condition")
+
         left = f"{quote_columnname(aliases[0], warehouse.name)}.{quote_columnname(condition['key1'], warehouse.name)}"
         right = f"{quote_columnname(aliases[1], warehouse.name)}.{quote_columnname(condition['key2'], warehouse.name)}"
-        on_clause.append(f"{left} {condition['compare_with']} {right}")
+        on_clause.append(f"{left} {op} {right}")
 
     dbt_code += " ON " + " AND ".join(on_clause) + "\n"
 

--- a/ddpui/core/dbt_automation/operations/joins.py
+++ b/ddpui/core/dbt_automation/operations/joins.py
@@ -104,8 +104,14 @@ def joins_sql(
             f" {join_type.upper()} JOIN " + "{{" + join_with + "}}" + " " + aliases[1] + "\n"
         )
 
-    dbt_code += f" ON {quote_columnname(aliases[0], warehouse.name)}.{quote_columnname(join_on['key1'], warehouse.name)}"
-    dbt_code += f" {join_on['compare_with']} {quote_columnname(aliases[1], warehouse.name)}.{quote_columnname(join_on['key2'], warehouse.name)}\n"
+    join_conditions = join_on if isinstance(join_on, list) else [join_on]
+    on_clause = []
+    for condition in join_conditions:
+        left = f"{quote_columnname(aliases[0], warehouse.name)}.{quote_columnname(condition['key1'], warehouse.name)}"
+        right = f"{quote_columnname(aliases[1], warehouse.name)}.{quote_columnname(condition['key2'], warehouse.name)}"
+        on_clause.append(f"{left} {condition['compare_with']} {right}")
+
+    dbt_code += " ON " + " AND ".join(on_clause) + "\n"
 
     return dbt_code, list(output_set)
 

--- a/ddpui/schemas/dbt_workflow_schema.py
+++ b/ddpui/schemas/dbt_workflow_schema.py
@@ -1,6 +1,6 @@
 from ninja import Field, Schema
 from typing import Union, Any, Literal, Optional
-from pydantic import ConfigDict
+from pydantic import ConfigDict, validator
 
 from ddpui.models.dbt_workflow import OrgDbtModel
 from ddpui.models.canvas_models import CanvasNode
@@ -215,6 +215,12 @@ class JoinOperationConfig(Schema):
 
     join_type: Literal["inner", "left", "full outer"]
     join_on: Union[JoinOnConditionConfig, list[JoinOnConditionConfig]]
+
+    @validator("join_on")
+    def validate_join_on(cls, v):
+        if isinstance(v, list) and len(v) == 0:
+            raise ValueError("join_on list cannot be empty")
+        return v
 
 
 class UnionTablesOperationConfig(Schema):

--- a/ddpui/schemas/dbt_workflow_schema.py
+++ b/ddpui/schemas/dbt_workflow_schema.py
@@ -201,6 +201,8 @@ class GroupByOperationConfig(Schema):
 class JoinOnConditionConfig(Schema):
     """Schema for individual join on condition"""
 
+    model_config = ConfigDict(str_strip_whitespace=True)
+
     key1: str
     key2: str
     compare_with: str
@@ -209,8 +211,10 @@ class JoinOnConditionConfig(Schema):
 class JoinOperationConfig(Schema):
     """Config for join operations"""
 
+    model_config = ConfigDict(str_strip_whitespace=True)
+
     join_type: Literal["inner", "left", "full outer"]
-    join_on: JoinOnConditionConfig
+    join_on: Union[JoinOnConditionConfig, list[JoinOnConditionConfig]]
 
 
 class UnionTablesOperationConfig(Schema):

--- a/ddpui/schemas/dbt_workflow_schema.py
+++ b/ddpui/schemas/dbt_workflow_schema.py
@@ -207,6 +207,13 @@ class JoinOnConditionConfig(Schema):
     key2: str
     compare_with: str
 
+    @validator("compare_with")
+    def validate_compare_with(cls, v):
+        allowed_operators = ["=", "!=", "<>", ">", "<", ">=", "<=", "LIKE", "ILIKE"]
+        if v.upper() not in allowed_operators:
+            raise ValueError(f"Operator {v} not allowed. Must be one of {allowed_operators}")
+        return v.upper()
+
 
 class JoinOperationConfig(Schema):
     """Config for join operations"""

--- a/ddpui/schemas/dbt_workflow_schema.py
+++ b/ddpui/schemas/dbt_workflow_schema.py
@@ -209,6 +209,7 @@ class JoinOnConditionConfig(Schema):
 
     @validator("compare_with")
     def validate_compare_with(cls, v):
+        """Validate that the comparison operator is in the allowed whitelist"""
         allowed_operators = ["=", "!=", "<>", ">", "<", ">=", "<=", "LIKE", "ILIKE"]
         if v.upper() not in allowed_operators:
             raise ValueError(f"Operator {v} not allowed. Must be one of {allowed_operators}")
@@ -225,6 +226,7 @@ class JoinOperationConfig(Schema):
 
     @validator("join_on")
     def validate_join_on(cls, v):
+        """Validate that the join_on list is not empty if provided as a list"""
         if isinstance(v, list) and len(v) == 0:
             raise ValueError("join_on list cannot be empty")
         return v


### PR DESCRIPTION
Fixes #975

Allows join operations to specify multiple join keys in the UI4T transformation engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Join operations now support multiple join conditions, allowing users to specify several conditions simultaneously within a single operation instead of just one.

* **Improvements**
  * Automatic whitespace trimming added to join configuration inputs for cleaner data handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DalgoT4D/DDP_backend/pull/1340)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->