### PR TITLE
Operations to provide their input schema (#973)

### DIFF
--- a/ddpui/api/transform_api.py
+++ b/ddpui/api/transform_api.py
@@ -27,6 +27,7 @@ from ddpui.schemas.dbt_workflow_schema import (
     ModelSrcInputsForMultiInputOp,
     validate_operation_config_v2,
     TerminateChainAndCreateModelPayload,
+    get_operation_schemas,
 )
 from ddpui.core.orgdbt_manager import DbtProjectManager
 from ddpui.utils.taskprogress import TaskProgress
@@ -608,6 +609,16 @@ def post_create_src_model_node(request, dbtmodel_uuid: str):
         logger.error(f"Failed to create source/model node: {str(e)}")
         # Transaction will automatically rollback due to the exception
         raise HttpError(500, f"Failed to create node: {str(e)}")
+
+
+@transform_router.get("/v2/dbt_project/operations/schemas/")
+@has_permission(["can_view_dbt_workspace"])
+def get_operation_input_schemas(request):
+    """
+    Returns the JSON schemas for all available transformation operations.
+    This allows the frontend to dynamically generate UI forms for operations.
+    """
+    return get_operation_schemas()
 
 
 @transform_router.post("/v2/dbt_project/operations/nodes/")

--- a/ddpui/schemas/dbt_workflow_schema.py
+++ b/ddpui/schemas/dbt_workflow_schema.py
@@ -308,6 +308,19 @@ op_config_mapping = {
 }
 
 
+def get_operation_schemas() -> dict:
+    """Return JSON schemas for all operations"""
+    schemas = {}
+    for op_type, schema_class in op_config_mapping.items():
+        try:
+            # For Ninja/Pydantic V2
+            schemas[op_type] = schema_class.model_json_schema()
+        except AttributeError:
+            # Fallback for Pydantic V1 if needed
+            schemas[op_type] = schema_class.schema()
+    return schemas
+
+
 def validate_operation_config_v2(op_type: str, config: dict) -> None:
     """Validate config based on operation type"""
 


### PR DESCRIPTION
Fixes #973

Exposes JSON schemas for all transformation operations via a new API endpoint, allowing the frontend to dynamically render configuration forms.