### PR TITLE
Recreate a partially created dbt workspace (#529)

### DIFF
--- a/ddpui/core/git_manager.py
+++ b/ddpui/core/git_manager.py
@@ -368,14 +368,14 @@ class GitManager:
                     pat=org_admin_pat,
                     method="GET",
                 )
-            elif status_code == 401:
+            if status_code == 401:
                 raise GitManagerError("Authentication failed - check PAT permissions") from e
-            elif status_code == 403:
+            if status_code == 403:
                 raise GitManagerError(
                     "Insufficient permissions to create repository in organization"
                 ) from e
-            else:
-                raise GitManagerError(f"GitHub API error: HTTP {status_code}: {str(e)}") from e
+            
+            raise GitManagerError(f"GitHub API error: HTTP {status_code}: {str(e)}") from e
         except requests.RequestException as e:
             raise GitManagerError(
                 f"Network error: Failed to connect to GitHub API: {str(e)}"

--- a/ddpui/core/git_manager.py
+++ b/ddpui/core/git_manager.py
@@ -361,9 +361,13 @@ class GitManager:
         except requests.HTTPError as e:
             status_code = e.response.status_code
             if status_code == 422:
-                raise GitManagerError(
-                    f"Repository {repo_name} already exists or name is invalid"
-                ) from e
+                # If repository already exists, fetch and return its data
+                logger.info(f"Repository {repo_name} already exists, fetching existing repo data")
+                return GitManager._github_api_request(
+                    url=f"https://api.github.com/repos/{dalgo_github_org}/{repo_name}",
+                    pat=org_admin_pat,
+                    method="GET",
+                )
             elif status_code == 401:
                 raise GitManagerError("Authentication failed - check PAT permissions") from e
             elif status_code == 403:

--- a/ddpui/ddpdbt/dbt_service.py
+++ b/ddpui/ddpdbt/dbt_service.py
@@ -368,9 +368,10 @@ def setup_managed_git_workspace(org: Org, project_name: str, default_schema: str
             orgdbt.is_repo_managed_by_system = True
             orgdbt.save()
 
-        # 6. Check if project already exists
+        # 6. Check if project already exists - if it does, wipe it for recreation (Issue #529)
         if dbtrepo_dir.exists():
-            raise Exception(f"Project {project_name} already exists")
+            logger.warning(f"Project {project_name} already exists at {dbtrepo_dir}. Cleaning up for recreation.")
+            shutil.rmtree(dbtrepo_dir)
 
         if not project_dir.exists():
             project_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes #529

Improves robustness of dbt workspace creation by:
1. Making repository creation idempotent (returns existing repo if it already exists).
2. Automatically cleaning up existing local directories if a workspace creation is retried.
This allows users to recover from failed setup attempts without manual intervention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository creation now handles already-existing repositories gracefully instead of failing
  * Workspace setup can be re-run without manual cleanup or causing errors, improving workflow reliability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DalgoT4D/DDP_backend/pull/1342)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->