### PR TITLE
fix: suppress false-positive dimension warning for number charts

### DIFF
--- a/ddpui/core/charts/charts_service.py
+++ b/ddpui/core/charts/charts_service.py
@@ -156,7 +156,9 @@ def normalize_dimensions(payload: ChartDataPayload) -> List[str]:
         if payload.extra_dimension:
             final_dims.append(payload.extra_dimension)
 
-    if not final_dims:
+    # number charts aggregate to a single value and don't use dimensions
+    DIMENSIONLESS_CHART_TYPES = {"number"}
+    if not final_dims and payload.chart_type not in DIMENSIONLESS_CHART_TYPES:
         logger.warning(f"No valid dimensions found {payload.dimensions}")
 
     return final_dims


### PR DESCRIPTION
## Summary

- `normalize_dimensions` was logging a warning whenever `final_dims` was empty, but `number` charts legitimately have no dimensions — they return a single aggregated value with no grouping
- This caused ~9,000 noise events in Sentry ([DALGO-BACKEND-253](https://dalgo.sentry.io/issues/DALGO-BACKEND-253)) across 62 users since Feb 2026, firing on every number/KPI chart load
- Fix: skip the warning for chart types that are designed to be dimensionless (`number`)

## Test plan

- [ ] Load a number/KPI chart and verify no warning appears in logs
- [ ] Load a bar/line/pie chart with no dimension configured and verify the warning still fires
- [ ] Existing chart tests pass

Fixes DALGO-BACKEND-253

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the chart dimension validation system to properly handle and recognize dimensionless chart types, including number charts. These chart types no longer generate unnecessary validation warnings during the chart normalization process, delivering a cleaner and more streamlined user experience when creating and working with various chart types throughout the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DalgoT4D/DDP_backend/pull/1345)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->