### PR TITLE
Fix notification read_status filtering

### DIFF
--- a/ddpui/api/notifications_api.py
+++ b/ddpui/api/notifications_api.py
@@ -46,7 +46,7 @@ def get_notification_history(request, page: int = 1, limit: int = 10, read_statu
     Returns all the notifications including the
     past and the future scheduled notifications
     """
-    error, result = notifications_functions.get_notification_history(page, limit, read_status=None)
+    error, result = notifications_functions.get_notification_history(page, limit, read_status = read_status)
     if error is not None:
         raise HttpError(400, error)
 

--- a/ddpui/api/notifications_api.py
+++ b/ddpui/api/notifications_api.py
@@ -46,7 +46,7 @@ def get_notification_history(request, page: int = 1, limit: int = 10, read_statu
     Returns all the notifications including the
     past and the future scheduled notifications
     """
-    error, result = notifications_functions.get_notification_history(page, limit, read_status = read_status)
+    error, result = notifications_functions.get_notification_history(page, limit, read_status=read_status)
     if error is not None:
         raise HttpError(400, error)
 

--- a/ddpui/core/notifications/notifications_functions.py
+++ b/ddpui/core/notifications/notifications_functions.py
@@ -176,7 +176,7 @@ def get_notification_history(
     """returns history of sent notifications"""
     notifications = Notification.objects
 
-    if read_status:
+    if read_status is not None:
         notifications = notifications.filter(read_status=(read_status == 1))
 
     notifications = notifications.all().order_by("-timestamp")


### PR DESCRIPTION
Fixed notification history filtering by correctly forwarding the read_status parameter from the API layer and updating the downstream condition to check for None explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed notification history filtering to correctly handle all read status values, including when filtering for unread notifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DalgoT4D/DDP_backend/pull/1347)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->