### PR TITLE
Refactor DashboardFilterResponse serialization

### DIFF
--- a/ddpui/api/dashboard_native_api.py
+++ b/ddpui/api/dashboard_native_api.py
@@ -340,7 +340,7 @@ def create_filter(request, dashboard_id: int, payload: FilterCreate):
     except FilterValidationError as err:
         raise HttpError(400, err.message) from err
 
-    return DashboardFilterResponse(**filter_obj.to_json())
+    return DashboardFilterResponse.from_model(filter_obj)
 
 
 @dashboard_native_router.get(
@@ -358,7 +358,7 @@ def get_filter(request, dashboard_id: int, filter_id: int):
     except FilterNotFoundError as err:
         raise HttpError(404, "Filter not found") from err
 
-    return DashboardFilterResponse(**filter_obj.to_json())
+    return DashboardFilterResponse.from_model(filter_obj)
 
 
 @dashboard_native_router.put(
@@ -383,7 +383,7 @@ def update_filter(request, dashboard_id: int, filter_id: int, payload: FilterUpd
     except FilterValidationError as err:
         raise HttpError(400, err.message) from err
 
-    return DashboardFilterResponse(**filter_obj.to_json())
+    return DashboardFilterResponse.from_model(filter_obj)
 
 
 @dashboard_native_router.delete("/{dashboard_id}/filters/{filter_id}/")

--- a/ddpui/schemas/dashboard_schema.py
+++ b/ddpui/schemas/dashboard_schema.py
@@ -52,6 +52,7 @@ class DashboardFilterResponse(Schema):
 
     @classmethod
     def from_model(cls, filter_obj):
+        """Create response schema from dashboard filter model."""
         return cls(**filter_obj.to_json())
 
 

--- a/ddpui/schemas/dashboard_schema.py
+++ b/ddpui/schemas/dashboard_schema.py
@@ -50,6 +50,10 @@ class DashboardFilterResponse(Schema):
     created_at: datetime
     updated_at: datetime
 
+    @classmethod
+    def from_model(cls, filter_obj):
+        return cls(**filter_obj.to_json())
+
 
 class DashboardResponse(Schema):
     """Response schema for dashboard"""


### PR DESCRIPTION
Added a from_model() classmethod to DashboardFilterResponse and replaced direct model serialization calls in dashboard_native_api.py. This decouples the API layer from the model's internal to_json() implementation while preserving the existing response shape and API contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of dashboard filter responses for better code maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DalgoT4D/DDP_backend/pull/1349)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->