### PR TITLE
fix: apply 24h TTL to email verification tokens to match password reset flow

### DIFF
--- a/ddpui/core/orguserfunctions.py
+++ b/ddpui/core/orguserfunctions.py
@@ -136,6 +136,7 @@ def signup_orguser(payload: OrgUserCreate):
     orguserid_bytes = str(orguser.id).encode("utf8")
 
     redis.set(redis_key, orguserid_bytes)
+    redis.expire(redis_key, 3600 * 24)  # 24 hours TTL
 
     FRONTEND_URL = os.getenv("FRONTEND_URL")
     reset_url = f"{FRONTEND_URL}/verifyemail/?token={token.hex}"
@@ -393,7 +394,7 @@ def request_reset_password(email: str, is_v2: bool = False):
     orguserid_bytes = str(orguser.id).encode("utf8")
 
     redis.set(redis_key, orguserid_bytes)
-    redis.expire(redis_key, 3600 * 24)  # 24 hours
+    redis.expire(redis_key, 3600 * 24)  # 24 hours TTL
 
     # To seperate the frontend urls for v1 and v2
     FRONTEND_URL = os.getenv("FRONTEND_URL_V2") if is_v2 else os.getenv("FRONTEND_URL")
@@ -450,6 +451,7 @@ def resend_verification_email(orguser: OrgUser, email: str):
     orguserid_bytes = str(orguser.id).encode("utf8")
 
     redis.set(redis_key, orguserid_bytes)
+    redis.expire(redis_key, 3600 * 24)  # 24 hours TTL
 
     FRONTEND_URL = os.getenv("FRONTEND_URL")
     reset_url = f"{FRONTEND_URL}/verifyemail/?token={token.hex}"


### PR DESCRIPTION
Fixes #1314

## Summary
Fixes email verification tokens being stored in Redis without expiration.

## Problem
In `signup_orguser()` and `resend_verification_email()`, tokens were 
stored using `redis.set()` without a TTL, unlike password reset tokens 
which explicitly use a 24-hour expiration via `redis.expire()`.

This caused:
- Stale verification tokens remaining valid indefinitely
- Redis accumulating unused verification keys over time
- Inconsistent token lifecycle behavior across flows

## Fix
Added `redis.expire(redis_key, 3600 * 24)` after `redis.set()` in both:
- `signup_orguser()` 
- `resend_verification_email()`

This matches the existing pattern used in `request_reset_password()`.

## Files Changed
- `ddpui/api/orguserfunctions.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email verification and password reset tokens now automatically expire after 24 hours for improved security and reliability.
  * Resent verification emails include tokens configured with 24-hour expiration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DalgoT4D/DDP_backend/pull/1357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->