### PR TITLE
fix: login breakage after user's email updates

### DIFF
--- a/ddpui/core/orguserfunctions.py
+++ b/ddpui/core/orguserfunctions.py
@@ -164,7 +164,9 @@ def update_orguser(orguser: OrgUser, payload: OrgUserUpdate):
 def update_orguser_v1(orguser: OrgUser, payload: OrgUserUpdatev1):
     """updates attributes of an OrgUser"""
     if payload.email:
-        orguser.user.email = payload.email.lower().strip()
+        email = payload.email.lower().strip()
+        orguser.user.email = email
+        orguser.user.username = email
     if payload.active is not None:
         orguser.user.is_active = payload.active
     if payload.role_uuid:

--- a/ddpui/tests/api_tests/test_user_org_api.py
+++ b/ddpui/tests/api_tests/test_user_org_api.py
@@ -419,9 +419,11 @@ def test_put_organization_user_self_v1(orguser):
     )
 
     response = put_organization_user_self_v1(request, payload)
+    orguser.user.refresh_from_db()
 
     assert response.email == "newemail"
     assert response.active is new_active_status
+    assert orguser.user.username == "newemail"
 
 
 # ================================================================================
@@ -451,7 +453,10 @@ def test_put_organization_user_v1(orguser, nonadminorguser):
     )
 
     response = put_organization_user_v1(request, payload)
+    nonadminorguser.user.refresh_from_db()
+
     assert response.email == payload.email
+    assert nonadminorguser.user.username == payload.email
 
 
 # ================================================================================


### PR DESCRIPTION
Fixes : #1358 

This PR keeps Django _`User.username`_ in sync when a user’s email is updated through the org user update flow.

**Changes** : 
- Update `User.username` whenever `User.email` is updated in update_orguser_v1
- Add regression assertions for self user updates and admin user updates



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured user account username is properly synchronized with email updates, maintaining data consistency across user profiles.

* **Tests**
  * Enhanced test coverage to verify username field persistence in the database following email updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DalgoT4D/DDP_backend/pull/1359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->