### PR TITLE
fix: apply dashboard filters to chart CSV download

### DIFF
--- a/ddpui/api/charts_api.py
+++ b/ddpui/api/charts_api.py
@@ -948,8 +948,11 @@ def stream_chart_data_csv(org_warehouse, payload: ChartDataPayload, page_size=50
 
 @charts_router.post("/download-csv/")
 @has_permission(["can_view_charts"])
-def download_chart_data_csv(request, payload: ChartDataPayload):
+def download_chart_data_csv(
+    request, payload: ChartDataPayload, dashboard_filters: Optional[str] = None
+):
     """Stream and download chart data as CSV with all filters/aggregations applied (authenticated)"""
+    import json
 
     orguser: OrgUser = request.orguser
 
@@ -961,6 +964,26 @@ def download_chart_data_csv(request, payload: ChartDataPayload):
 
     if not org_warehouse:
         raise HttpError(404, "Please set up your warehouse first")
+
+    # Resolve dashboard filters server-side (same as get_chart_data_by_id) so the
+    # CSV matches the on-screen chart.
+    if dashboard_filters:
+        try:
+            filter_values = json.loads(dashboard_filters)
+        except json.JSONDecodeError:
+            logger.error(f"Invalid dashboard_filters JSON: {dashboard_filters}")
+            filter_values = None
+
+        if filter_values:
+            warehouse_client = WarehouseFactory.get_warehouse_client(org_warehouse)
+            filter_defs = DashboardFilter.objects.filter(id__in=filter_values.keys())
+            payload.dashboard_filters = DashboardService.resolve_dashboard_filters_for_chart(
+                filter_values,
+                [f.to_json() for f in filter_defs],
+                payload.schema_name,
+                payload.table_name,
+                warehouse_client,
+            )
 
     # Generate filename from chart configuration
     chart_type = payload.chart_type or "chart"

--- a/ddpui/api/public_api.py
+++ b/ddpui/api/public_api.py
@@ -892,7 +892,13 @@ def get_region_geojsons_public(request, region_id: int):
 
 
 @public_router.post("/dashboards/{token}/charts/{chart_id}/download-csv/")
-def download_public_chart_data_csv(request, token: str, chart_id: int, payload: ChartDataPayload):
+def download_public_chart_data_csv(
+    request,
+    token: str,
+    chart_id: int,
+    payload: ChartDataPayload,
+    dashboard_filters: Optional[str] = None,
+):
     """
     Stream and download chart data as CSV for public dashboards
 
@@ -920,6 +926,27 @@ def download_public_chart_data_csv(request, token: str, chart_id: int, payload: 
         org_warehouse = OrgWarehouse.objects.filter(org=dashboard.org).first()
         if not org_warehouse:
             raise HttpError(404, "No warehouse configured for organization")
+
+        # Resolve dashboard filters via column_exists (same as on-screen fetch).
+        if dashboard_filters:
+            try:
+                filter_values = json.loads(dashboard_filters)
+            except json.JSONDecodeError:
+                logger.error(f"Invalid dashboard_filters JSON: {dashboard_filters}")
+                filter_values = None
+
+            if filter_values:
+                warehouse_client = WarehouseFactory.get_warehouse_client(org_warehouse)
+                filter_defs = DashboardFilter.objects.filter(
+                    id__in=filter_values.keys(), dashboard=dashboard
+                )
+                payload.dashboard_filters = DashboardService.resolve_dashboard_filters_for_chart(
+                    filter_values,
+                    [f.to_json() for f in filter_defs],
+                    payload.schema_name,
+                    payload.table_name,
+                    warehouse_client,
+                )
 
         # Import the common CSV streaming function
         from ddpui.api.charts_api import stream_chart_data_csv


### PR DESCRIPTION
Resolve the dashboard_filters query param server-side in the authenticated and public CSV endpoints (via resolve_dashboard_filters_for_chart), so CSV exports match the on-screen filtered chart instead of returning all rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CSV downloads now support dashboard filters, ensuring exported data matches your filtered chart view for both authenticated and public chart exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->