### PR TITLE
feat: expose user_id and subscription_plan on currentuser response

### DIFF
--- a/ddpui/api/user_org_api.py
+++ b/ddpui/api/user_org_api.py
@@ -112,6 +112,7 @@ def get_current_user_v2(request, org_slug: str = None):
 
         res.append(
             OrgUserResponse(
+                user_id=user.id,
                 email=user.email,
                 org=curr_orguser.org,
                 active=user.is_active,
@@ -127,6 +128,7 @@ def get_current_user_v2(request, org_slug: str = None):
                 is_llm_active=org_preferences.llm_optin,
                 landing_dashboard_id=curr_orguser.landing_dashboard_id,
                 org_default_dashboard_id=org_default_dashboard,
+                subscription_plan=(curr_orguser.org.base_plan() if curr_orguser.org else None),
             )
         )
 
@@ -267,6 +269,7 @@ def get_organization_users(request):
             curr_orguser.org.tnc_accepted = curr_orguser.org.orgtncs.exists()
         res.append(
             OrgUserResponse(
+                user_id=curr_orguser.user.id,
                 email=curr_orguser.user.email,
                 org=curr_orguser.org,
                 active=curr_orguser.user.is_active,
@@ -279,6 +282,7 @@ def get_organization_users(request):
                 is_demo=(
                     curr_orguser.org.base_plan() == OrgType.DEMO if curr_orguser.org else False
                 ),
+                subscription_plan=(curr_orguser.org.base_plan() if curr_orguser.org else None),
             )
         )
 

--- a/ddpui/models/org_user.py
+++ b/ddpui/models/org_user.py
@@ -127,6 +127,7 @@ class OrgUserUpdateNewRole(Schema):
 class OrgUserResponse(Schema):
     """structure for returning an OrgUser in an http response"""
 
+    user_id: int
     email: str
     org: Optional[OrgSchema] = None
     active: bool
@@ -137,6 +138,7 @@ class OrgUserResponse(Schema):
     is_llm_active: Optional[bool] = None
     landing_dashboard_id: int | None = None
     org_default_dashboard_id: int | None = None
+    subscription_plan: str | None = None
 
 
 class Invitation(models.Model):

--- a/ddpui/utils/orguserhelpers.py
+++ b/ddpui/utils/orguserhelpers.py
@@ -23,6 +23,7 @@ def from_orguser(orguser: OrgUser) -> OrgUserResponse:
     ]
 
     response = OrgUserResponse(
+        user_id=orguser.user.id,
         email=orguser.user.email,
         org=orguser.org,
         active=orguser.user.is_active,
@@ -30,6 +31,7 @@ def from_orguser(orguser: OrgUser) -> OrgUserResponse:
         permissions=permissions,
         wtype=warehouse.wtype if warehouse else None,
         is_demo=orguser.org.base_plan() == OrgType.DEMO if orguser.org else False,
+        subscription_plan=orguser.org.base_plan() if orguser.org else None,
     )
     if orguser.org:
         response.org.tnc_accepted = OrgTnC.objects.filter(org=orguser.org).exists()


### PR DESCRIPTION
Adds user_id (Django auth_user PK) and subscription_plan (org base_plan) to OrgUserResponse so the frontend can identify users in analytics by a stable, non-PII id instead of email, and segment by org plan. user_id is required, so all three OrgUserResponse constructors (currentuserv2, get_organization_users, from_orguser) are updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization user endpoints now return additional user information, including user ID and subscription plan details in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->