### PR TITLE
delete chart config from dashboard , when we delete the chart

### DIFF
--- a/ddpui/services/chart_service.py
+++ b/ddpui/services/chart_service.py
@@ -7,6 +7,7 @@ separating it from the API layer for better testability and maintainability.
 from typing import Dict, List, Optional, Tuple, Any
 from dataclasses import dataclass
 
+from django.db import transaction
 from django.db.models import Q
 
 from ddpui.models.visualization import Chart
@@ -260,10 +261,58 @@ class ChartService:
             raise ChartPermissionError("You can only delete charts you created.")
 
         chart_title = chart.title
-        chart.delete()
+
+        # Cascade cleanup + delete must succeed together: either the chart is gone AND
+        # every dashboard reference to it is stripped, or neither happens. Otherwise a
+        # dashboard would keep a dangling chart tile that renders as a broken "Chart Error".
+        with transaction.atomic():
+            ChartService._remove_chart_from_dashboards([chart_id], org)
+            chart.delete()
 
         logger.info(f"Deleted chart '{chart_title}' (id={chart_id}) by {orguser.user.email}")
         return True
+
+    @staticmethod
+    def _remove_chart_from_dashboards(chart_ids: List[int], org: Org) -> None:
+        """Strip the given charts from every dashboard in the org that embeds them.
+
+        Removes the chart component(s) from each tab's ``components`` map and drops the
+        matching grid items from ``layout_config`` (keyed by component id). Saves only
+        dashboards that actually changed.
+        """
+        chart_id_set = set(chart_ids)
+
+        for dashboard in Dashboard.objects.filter(org=org):
+            changed = False
+
+            for tab in dashboard.tabs or []:
+                components = tab.get("components") or {}
+                component_ids_to_remove = [
+                    component_id
+                    for component_id, component in components.items()
+                    if component.get("type") == DashboardComponentType.CHART.value
+                    and component.get("config", {}).get("chartId") in chart_id_set
+                ]
+
+                if not component_ids_to_remove:
+                    continue
+
+                for component_id in component_ids_to_remove:
+                    components.pop(component_id, None)
+                tab["components"] = components
+                tab["layout_config"] = [
+                    item
+                    for item in (tab.get("layout_config") or [])
+                    if item.get("i") not in component_ids_to_remove
+                ]
+                changed = True
+
+            if changed:
+                dashboard.save(update_fields=["tabs", "updated_at"])
+                logger.info(
+                    f"Removed chart(s) {sorted(chart_id_set)} from dashboard "
+                    f"'{dashboard.title}' (id={dashboard.id})"
+                )
 
     @staticmethod
     def bulk_delete_charts(chart_ids: List[int], org: Org, orguser: OrgUser) -> Dict[str, Any]:
@@ -293,8 +342,10 @@ class ChartService:
         if missing_ids:
             logger.warning(f"Charts not found or not accessible: {missing_ids}")
 
-        # Delete the charts
-        deleted_count = charts.delete()[0]
+        # Cascade cleanup + delete atomically so dashboards never keep dangling tiles.
+        with transaction.atomic():
+            ChartService._remove_chart_from_dashboards(found_ids, org)
+            deleted_count = charts.delete()[0]
 
         logger.info(f"Bulk deleted {deleted_count} charts by {orguser.user.email}")
 

--- a/ddpui/tests/services/test_chart_service.py
+++ b/ddpui/tests/services/test_chart_service.py
@@ -279,6 +279,191 @@ class TestGetChartDashboards:
 
 
 # ================================================================================
+# Test cascade cleanup: deleting a chart strips it from dashboards that embed it
+# ================================================================================
+
+
+class TestDeleteChartCascadeCleanup:
+    """Tests that delete_chart / bulk_delete_charts remove the chart from dashboards.
+
+    Without this, the dashboard keeps a dangling chart tile that renders as a broken
+    "Chart Error" because it points at a deleted chart id.
+    """
+
+    def _make_dashboard_with_chart(self, orguser, org, chart_id, extra_components=None):
+        """Build a dashboard whose tab embeds chart_id as component 'chart-comp-1'.
+
+        The grid layout_config references the component by its key under 'i'.
+        """
+        components = {
+            "chart-comp-1": {
+                "id": "chart-comp-1",
+                "type": DashboardComponentType.CHART.value,
+                "config": {"chartId": chart_id},
+            }
+        }
+        layout_config = [{"i": "chart-comp-1", "x": 0, "y": 0, "w": 6, "h": 4}]
+        if extra_components:
+            components.update(extra_components)
+            for comp_id in extra_components:
+                layout_config.append({"i": comp_id, "x": 6, "y": 0, "w": 6, "h": 4})
+
+        return Dashboard.objects.create(
+            title="Dashboard With Chart",
+            dashboard_type="native",
+            grid_columns=12,
+            tabs=[
+                {
+                    "id": "tab-1",
+                    "title": "Tab 1",
+                    "layout_config": layout_config,
+                    "components": components,
+                }
+            ],
+            created_by=orguser,
+            org=org,
+        )
+
+    def test_delete_chart_removes_it_from_dashboard(self, orguser, org, seed_db):
+        """Deleting a chart strips its component + layout item from the dashboard."""
+        chart = Chart.objects.create(
+            title="Embedded Chart",
+            chart_type="bar",
+            schema_name="public",
+            table_name="users",
+            extra_config={},
+            created_by=orguser,
+            last_modified_by=orguser,
+            org=org,
+        )
+        dashboard = self._make_dashboard_with_chart(orguser, org, chart.id)
+
+        ChartService.delete_chart(chart.id, org, orguser)
+
+        dashboard.refresh_from_db()
+        tab = dashboard.tabs[0]
+        assert "chart-comp-1" not in tab["components"]
+        assert all(item["i"] != "chart-comp-1" for item in tab["layout_config"])
+        assert not Chart.objects.filter(id=chart.id).exists()
+
+        dashboard.delete()
+
+    def test_delete_chart_leaves_other_components_intact(self, orguser, org, seed_db):
+        """Only the deleted chart's component is removed; siblings stay."""
+        chart = Chart.objects.create(
+            title="Embedded Chart",
+            chart_type="bar",
+            schema_name="public",
+            table_name="users",
+            extra_config={},
+            created_by=orguser,
+            last_modified_by=orguser,
+            org=org,
+        )
+        other_component = {
+            "text-comp-1": {"id": "text-comp-1", "type": "text", "config": {"content": "hi"}}
+        }
+        dashboard = self._make_dashboard_with_chart(
+            orguser, org, chart.id, extra_components=other_component
+        )
+
+        ChartService.delete_chart(chart.id, org, orguser)
+
+        dashboard.refresh_from_db()
+        tab = dashboard.tabs[0]
+        assert "chart-comp-1" not in tab["components"]
+        assert "text-comp-1" in tab["components"]
+        assert any(item["i"] == "text-comp-1" for item in tab["layout_config"])
+
+        dashboard.delete()
+
+    def test_delete_chart_not_in_any_dashboard_is_noop(self, orguser, org, seed_db):
+        """A chart used by no dashboard deletes cleanly without touching dashboards."""
+        chart = Chart.objects.create(
+            title="Lonely Chart",
+            chart_type="bar",
+            schema_name="public",
+            table_name="users",
+            extra_config={},
+            created_by=orguser,
+            last_modified_by=orguser,
+            org=org,
+        )
+        # A dashboard that embeds a DIFFERENT chart id must be left untouched.
+        dashboard = self._make_dashboard_with_chart(orguser, org, chart_id=999999)
+
+        ChartService.delete_chart(chart.id, org, orguser)
+
+        dashboard.refresh_from_db()
+        assert "chart-comp-1" in dashboard.tabs[0]["components"]
+        assert not Chart.objects.filter(id=chart.id).exists()
+
+        dashboard.delete()
+
+    def test_bulk_delete_removes_charts_from_dashboard(self, orguser, org, seed_db):
+        """Bulk delete strips every deleted chart from the dashboards using them."""
+        chart1 = Chart.objects.create(
+            title="Chart 1",
+            chart_type="bar",
+            schema_name="public",
+            table_name="users",
+            extra_config={},
+            created_by=orguser,
+            last_modified_by=orguser,
+            org=org,
+        )
+        chart2 = Chart.objects.create(
+            title="Chart 2",
+            chart_type="bar",
+            schema_name="public",
+            table_name="users",
+            extra_config={},
+            created_by=orguser,
+            last_modified_by=orguser,
+            org=org,
+        )
+        dashboard = Dashboard.objects.create(
+            title="Dashboard Two Charts",
+            dashboard_type="native",
+            grid_columns=12,
+            tabs=[
+                {
+                    "id": "tab-1",
+                    "title": "Tab 1",
+                    "layout_config": [
+                        {"i": "c1", "x": 0, "y": 0, "w": 6, "h": 4},
+                        {"i": "c2", "x": 6, "y": 0, "w": 6, "h": 4},
+                    ],
+                    "components": {
+                        "c1": {
+                            "id": "c1",
+                            "type": DashboardComponentType.CHART.value,
+                            "config": {"chartId": chart1.id},
+                        },
+                        "c2": {
+                            "id": "c2",
+                            "type": DashboardComponentType.CHART.value,
+                            "config": {"chartId": chart2.id},
+                        },
+                    },
+                }
+            ],
+            created_by=orguser,
+            org=org,
+        )
+
+        result = ChartService.bulk_delete_charts([chart1.id, chart2.id], org, orguser)
+
+        assert result["deleted_count"] == 2
+        dashboard.refresh_from_db()
+        tab = dashboard.tabs[0]
+        assert tab["components"] == {}
+        assert tab["layout_config"] == []
+
+        dashboard.delete()
+
+
+# ================================================================================
 # Test get_org_warehouse
 # ================================================================================
 


### PR DESCRIPTION
[https://linear.app/dalgo/issue/DALGO-1418/when-a-chart-is-deleted-it-leaves-this-empty-block-with-an-error](https://linear.app/dalgo/issue/DALGO-1418/when-a-chart-is-deleted-it-leaves-this-empty-block-with-an-error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Charts are now automatically removed from all organization dashboards when deleted.
  * Chart deletion operations use atomic transactions to prevent orphaned chart tiles on dashboards.

* **Tests**
  * Added comprehensive tests for chart deletion cascade cleanup across dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->