### PR TITLE
Number formatting in kpis & its effect on KPIs, Alerts

### DIFF
--- a/ddpui/core/alerts/rendering.py
+++ b/ddpui/core/alerts/rendering.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import re
 from typing import Any, Mapping, Optional
 
+from ddpui.core.charts.number_formatting import format_number_v2
 from ddpui.models.alert import Alert, AlertType
 from ddpui.schemas.alert_schema import StandaloneConfig
 
@@ -100,10 +101,40 @@ def resolve_tokens(
     return base
 
 
+def _format_via_kpi_customizations(value: Any, customizations: Mapping[str, Any]) -> Any:
+    """Apply KPI display customizations to a numeric value.
+
+    Returns ``value`` unchanged if it's None (so the renderer's None-handling
+    leaves the token unresolved) or if it's not numeric. Otherwise mirrors
+    ``webapp_v2/lib/formatters.ts:formatKPIValue`` so email bodies stay
+    byte-identical with the KPI card.
+    """
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return value
+    return format_number_v2(
+        numeric,
+        format_type=customizations.get("numberFormat", "default") or "default",
+        decimal_places=customizations.get("decimalPlaces") or 0,
+        prefix=customizations.get("numberPrefix") or "",
+        suffix=customizations.get("numberSuffix") or "",
+    )
+
+
 def tokens_for_alert(
     alert: Alert, *, current_value: Any, rag_status: Optional[str] = None
 ) -> dict[str, Any]:
-    """Convenience helper — builds tokens from an Alert instance + a value."""
+    """Convenience helper — builds tokens from an Alert instance + a value.
+
+    For ``kpi_rag`` alerts, ``current_value`` and ``target_value`` are formatted
+    using the KPI's display customizations (``extra_config.customizations``) so
+    email bodies match the KPI card. If no ``numberFormat`` is configured, the
+    raw value passes through unchanged (matching frontend's ``formatKPIValue``
+    fallback to ``String(value)``).
+    """
     metric_name = alert.metric.name if alert.metric_id and alert.metric else None
     kpi_name = alert.kpi.name if alert.kpi_id and alert.kpi else None
 
@@ -118,6 +149,14 @@ def tokens_for_alert(
     else:
         cond = alert.condition or {}
         target_value = cond.get("value")
+
+    # Format kpi_rag current/target via the KPI's display customizations so the
+    # email body matches the KPI card byte-for-byte.
+    if alert.alert_type == AlertType.KPI_RAG and alert.kpi_id and alert.kpi:
+        cust = (alert.kpi.extra_config or {}).get("customizations") or {}
+        if isinstance(cust, dict) and cust.get("numberFormat"):
+            current_value = _format_via_kpi_customizations(current_value, cust)
+            target_value = _format_via_kpi_customizations(target_value, cust)
 
     return resolve_tokens(
         alert.alert_type,

--- a/ddpui/core/charts/echarts_config_generator.py
+++ b/ddpui/core/charts/echarts_config_generator.py
@@ -2,6 +2,8 @@
 
 from typing import Dict, List, Any, Optional
 
+from ddpui.core.charts.number_formatting import format_number_v2
+
 
 class EChartsConfigGenerator:
     """Generate ECharts configurations based on chart type and data"""
@@ -89,27 +91,8 @@ class EChartsConfigGenerator:
     def _format_number(
         value: float, format_type: str, decimal_places: int, prefix: str = "", suffix: str = ""
     ) -> str:
-        """Format number based on type, decimal places, prefix and suffix"""
-        # Handle None values
-        if value is None:
-            return "No data"
-
-        # Format the number based on type
-        if format_type == "percentage":
-            formatted = f"{value:.{decimal_places}f}%"
-        elif format_type == "currency":
-            formatted = f"${value:,.{decimal_places}f}"
-        else:  # default
-            if decimal_places > 0:
-                formatted = f"{value:.{decimal_places}f}"
-            else:
-                formatted = str(int(value)) if value == int(value) else str(value)
-
-        # Add prefix and suffix if provided
-        if prefix or suffix:
-            return f"{prefix}{formatted}{suffix}"
-
-        return formatted
+        """Format number for chart display. Delegates to the shared formatter."""
+        return format_number_v2(value, format_type, decimal_places, prefix, suffix)
 
     @staticmethod
     def generate_bar_config(data: Dict[str, Any], customizations: Dict[str, Any] = None) -> Dict:

--- a/ddpui/core/charts/number_formatting.py
+++ b/ddpui/core/charts/number_formatting.py
@@ -22,7 +22,6 @@ from babel.numbers import format_decimal
 _SUPPORTED_FORMATS = {
     "default",
     "percentage",
-    "currency",
     "indian",
     "international",
     "european",
@@ -74,18 +73,16 @@ def format_number_v2(
     decimal_places = max(0, min(10, decimal_places or 0))
 
     if format_type == "default":
-        formatted = _fixed(value, decimal_places) if decimal_places > 0 else (
-            str(int(value)) if value == int(value) else str(value)
+        formatted = (
+            _fixed(value, decimal_places)
+            if decimal_places > 0
+            else (str(int(value)) if value == int(value) else str(value))
         )
 
     elif format_type == "percentage":
-        formatted = _fixed(value, decimal_places) + "%"
-
-    elif format_type == "currency":
-        # "$" + en_US grouping (matches frontend)
-        formatted = "$" + format_decimal(
-            value, locale="en_US", format=_babel_format_string(decimal_places)
-        )
+        # Percentage semantics: value is a ratio (0.85 → 85.00%). Multiply by 100
+        # then render with the requested decimals + '%'.
+        formatted = _fixed(value * 100, decimal_places) + "%"
 
     elif format_type == "international":
         formatted = format_decimal(
@@ -110,8 +107,10 @@ def format_number_v2(
 
     else:
         # Unknown format → default (matches frontend's `default` branch behavior)
-        formatted = _fixed(value, decimal_places) if decimal_places > 0 else (
-            str(int(value)) if value == int(value) else str(value)
+        formatted = (
+            _fixed(value, decimal_places)
+            if decimal_places > 0
+            else (str(int(value)) if value == int(value) else str(value))
         )
 
     if prefix or suffix:

--- a/ddpui/core/charts/number_formatting.py
+++ b/ddpui/core/charts/number_formatting.py
@@ -1,0 +1,149 @@
+"""Shared number formatter — single source of truth for ``value → display string``.
+
+Used by:
+- ``echarts_config_generator._format_number`` (number-chart rendering)
+- KPI render paths (alert email body via ``{{current_value}}`` token)
+- Any future surface that needs a formatted numeric string server-side
+
+Mirrors ``webapp_v2/lib/formatters.ts:formatNumber`` for the seven supported
+formats, with the same decimal / locale / threshold semantics, so backend and
+frontend produce byte-identical output for the same inputs. A cross-stack
+parity fixture (see ``tests/fixtures/number_format_parity.json``) guards this.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+from babel.numbers import format_decimal
+
+
+_SUPPORTED_FORMATS = {
+    "default",
+    "percentage",
+    "currency",
+    "indian",
+    "international",
+    "european",
+    "adaptive_indian",
+    "adaptive_international",
+}
+
+
+def _babel_format_string(decimal_places: int) -> str:
+    """Build a babel format pattern for ``N`` decimal places."""
+    if decimal_places <= 0:
+        return "#,##0"
+    return "#,##0." + ("0" * decimal_places)
+
+
+def _indian_format_string(decimal_places: int) -> str:
+    """Indian lakh/crore grouping pattern for babel (``en_IN``)."""
+    if decimal_places <= 0:
+        return "#,##,##0"
+    return "#,##,##0." + ("0" * decimal_places)
+
+
+def _fixed(value: float, decimal_places: int) -> str:
+    """Mirror JS ``toFixed(n)``."""
+    return f"{value:.{decimal_places}f}"
+
+
+def format_number_v2(
+    value: Optional[float],
+    format_type: str = "default",
+    decimal_places: int = 0,
+    prefix: str = "",
+    suffix: str = "",
+) -> str:
+    """Format a numeric value for display.
+
+    Returns ``"No data"`` for ``None`` / ``NaN`` — without wrapping prefix/suffix.
+    Unrecognised ``format_type`` falls back to ``default`` (matches frontend).
+
+    See ``webapp_v2/lib/formatters.ts:formatNumber`` for the JS counterpart.
+    """
+    # None / NaN guard — also covers infinity since math.isfinite catches both
+    if value is None:
+        return "No data"
+    if isinstance(value, float) and not math.isfinite(value):
+        return "No data"
+
+    # Clamp decimal_places to the same [0, 10] range the frontend enforces
+    decimal_places = max(0, min(10, decimal_places or 0))
+
+    if format_type == "default":
+        formatted = _fixed(value, decimal_places) if decimal_places > 0 else (
+            str(int(value)) if value == int(value) else str(value)
+        )
+
+    elif format_type == "percentage":
+        formatted = _fixed(value, decimal_places) + "%"
+
+    elif format_type == "currency":
+        # "$" + en_US grouping (matches frontend)
+        formatted = "$" + format_decimal(
+            value, locale="en_US", format=_babel_format_string(decimal_places)
+        )
+
+    elif format_type == "international":
+        formatted = format_decimal(
+            value, locale="en_US", format=_babel_format_string(decimal_places)
+        )
+
+    elif format_type == "indian":
+        formatted = format_decimal(
+            value, locale="en_IN", format=_indian_format_string(decimal_places)
+        )
+
+    elif format_type == "european":
+        formatted = format_decimal(
+            value, locale="de_DE", format=_babel_format_string(decimal_places)
+        )
+
+    elif format_type == "adaptive_international":
+        formatted = _adaptive_international(value, decimal_places)
+
+    elif format_type == "adaptive_indian":
+        formatted = _adaptive_indian(value, decimal_places)
+
+    else:
+        # Unknown format → default (matches frontend's `default` branch behavior)
+        formatted = _fixed(value, decimal_places) if decimal_places > 0 else (
+            str(int(value)) if value == int(value) else str(value)
+        )
+
+    if prefix or suffix:
+        return f"{prefix}{formatted}{suffix}"
+    return formatted
+
+
+def _adaptive_international(value: float, decimal_places: int) -> str:
+    """K / M / B compact notation. Default 2 decimals if not specified."""
+    decimals = decimal_places if decimal_places else 2
+    abs_value = abs(value)
+    sign = "-" if value < 0 else ""
+
+    if abs_value >= 1_000_000_000:
+        return f"{sign}{_fixed(abs_value / 1_000_000_000, decimals)}B"
+    if abs_value >= 1_000_000:
+        return f"{sign}{_fixed(abs_value / 1_000_000, decimals)}M"
+    if abs_value >= 1_000:
+        return f"{sign}{_fixed(abs_value / 1_000, decimals)}K"
+    return _fixed(value, decimal_places) if decimal_places > 0 else str(value)
+
+
+def _adaptive_indian(value: float, decimal_places: int) -> str:
+    """K / L (Lakh) / Cr (Crore) compact notation. Default 2 decimals."""
+    decimals = decimal_places if decimal_places else 2
+    abs_value = abs(value)
+    sign = "-" if value < 0 else ""
+
+    if abs_value >= 10_000_000:
+        return f"{sign}{_fixed(abs_value / 10_000_000, decimals)}Cr"
+    if abs_value >= 100_000:
+        return f"{sign}{_fixed(abs_value / 100_000, decimals)}L"
+    if abs_value >= 1_000:
+        return f"{sign}{_fixed(abs_value / 1_000, decimals)}K"
+    return _fixed(value, decimal_places) if decimal_places > 0 else str(value)

--- a/ddpui/core/kpi/kpi_service.py
+++ b/ddpui/core/kpi/kpi_service.py
@@ -19,7 +19,13 @@ from ddpui.core.charts.charts_service import (
 from ddpui.core.charts.echarts_config_generator import EChartsConfigGenerator
 from ddpui.core.metric.metric_service import MetricService
 from ddpui.services.dashboard_service import DashboardService
-from ddpui.schemas.kpi_schema import KPICreate, KPIUpdate, KPIResponse, AnnotationEntryResponse
+from ddpui.schemas.kpi_schema import (
+    KPICreate,
+    KPIUpdate,
+    KPIResponse,
+    KPIExtraConfig,
+    AnnotationEntryResponse,
+)
 from ddpui.schemas.metric_schema import MetricResponse
 from ddpui.utils.warehouse.client.warehouse_factory import WarehouseFactory
 from ddpui.utils.custom_logger import CustomLogger
@@ -147,6 +153,7 @@ class KPIService:
             metric_type_tag=kpi.metric_type_tag,
             program_tags=kpi.program_tags,
             display_order=kpi.display_order,
+            extra_config=KPIExtraConfig(**(kpi.extra_config or {})),
             created_by=kpi.created_by.user.email,
             created_at=kpi.created_at,
             updated_at=kpi.updated_at,
@@ -223,6 +230,7 @@ class KPIService:
             time_dimension_column=payload.time_dimension_column,
             metric_type_tag=payload.metric_type_tag,
             program_tags=payload.program_tags,
+            extra_config=payload.extra_config.model_dump(),
             org=orguser.org,
             created_by=orguser,
             last_modified_by=orguser,
@@ -594,6 +602,14 @@ class KPIService:
             "time_grain": kpi_response.time_grain,
             "periods": periods,
             "data_last_date": data_last_date,
+            # Display customizations — surfaced so the dashboard widget and
+            # snapshot viewer can format the current value without needing a
+            # second fetch for the KPI's extra_config.
+            "customizations": (
+                kpi_response.extra_config.customizations.model_dump()
+                if kpi_response.extra_config and kpi_response.extra_config.customizations
+                else None
+            ),
         }
 
         # Generate echarts config

--- a/ddpui/core/reports/report_service.py
+++ b/ddpui/core/reports/report_service.py
@@ -19,7 +19,7 @@ from ddpui.utils.custom_logger import CustomLogger
 from ddpui.utils.warehouse.client.warehouse_factory import WarehouseFactory
 from ddpui.core.datainsights.insights.insight_interface import TranslateColDataType
 from ddpui.schemas.chart_schemas import ChartConfig
-from ddpui.schemas.kpi_schema import KPIResponse
+from ddpui.schemas.kpi_schema import KPIResponse, KPIExtraConfig
 from ddpui.schemas.metric_schema import MetricResponse
 from ddpui.schemas.report_schema import (
     DatetimeColumnResponse,
@@ -427,6 +427,10 @@ class ReportService:
             metric_type_tag=kpi_config.get("metric_type_tag"),
             program_tags=kpi_config.get("program_tags", []),
             display_order=0,
+            # M3 will wire the actual customizations from the frozen blob.
+            # For pre-v1.1 snapshots this stays empty — renders with no formatting,
+            # matching what those snapshots showed before v1.1.
+            extra_config=KPIExtraConfig(**kpi_config.get("extra_config", {})),
             # created_by is intentionally not frozen into report snapshots; shown only on the live KPI list
             created_by=kpi_config.get("created_by", ""),
             created_at=now,

--- a/ddpui/core/reports/report_service.py
+++ b/ddpui/core/reports/report_service.py
@@ -169,6 +169,10 @@ class ReportService:
                     metric_type_tag=kpi.metric_type_tag,
                     program_tags=kpi.program_tags,
                     periods=periods,
+                    # Freeze the KPI's display customizations so the snapshot
+                    # renders with the format active at snapshot time, not the
+                    # current live KPI's format.
+                    extra_config=kpi.extra_config or {},
                 )
                 frozen[str(kpi.id)] = frozen_kpi.model_dump()
 
@@ -427,8 +431,9 @@ class ReportService:
             metric_type_tag=kpi_config.get("metric_type_tag"),
             program_tags=kpi_config.get("program_tags", []),
             display_order=0,
-            # M3 will wire the actual customizations from the frozen blob.
-            # For pre-v1.1 snapshots this stays empty — renders with no formatting,
+            # Read customizations from the frozen blob (frozen at snapshot
+            # creation time — see ReportService._freeze_chart_configs). For
+            # pre-v1.1 snapshots this falls back to {} → no formatting,
             # matching what those snapshots showed before v1.1.
             extra_config=KPIExtraConfig(**kpi_config.get("extra_config", {})),
             # created_by is intentionally not frozen into report snapshots; shown only on the live KPI list

--- a/ddpui/management/commands/migrate_legacy_number_formats.py
+++ b/ddpui/management/commands/migrate_legacy_number_formats.py
@@ -1,0 +1,273 @@
+"""Migrate legacy ``numberFormat`` values on Chart + ReportSnapshot rows.
+
+Before this enhancement:
+- ``percentage`` simply appended ``%`` (no multiplication)
+- ``currency`` prepended ``$`` with en_US grouping
+
+After this enhancement:
+- ``percentage`` multiplies the value by 100 and appends ``%`` (real percent)
+- ``currency`` is removed; users use ``numberPrefix='$'`` instead
+
+This command rewrites every Chart row + every frozen chart config inside
+``ReportSnapshot.frozen_chart_configs`` holding a legacy value into a safe
+equivalent. ``FrozenKpiConfig`` entries (KPI snapshots) have no
+``extra_config`` field, so they are skipped automatically.
+
+Usage:
+    python manage.py migrate_legacy_number_formats --dry-run
+    python manage.py migrate_legacy_number_formats
+    python manage.py migrate_legacy_number_formats --charts-only
+    python manage.py migrate_legacy_number_formats --snapshots-only
+"""
+
+from django.core.management.base import BaseCommand
+
+from ddpui.models.report import ReportSnapshot
+from ddpui.models.visualization import Chart
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Transformation helpers (pure; no DB access)
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Number chart has ``numberPrefix`` / ``numberSuffix`` companion fields, so we
+# preserve the OLD render exactly:
+#
+#     percentage  → numberFormat="default"  + numberSuffix = (old) + "%"
+#     currency    → numberFormat="default"  + numberPrefix = "$" + (old)
+#
+# Pie ``numberFormat``, Bar/Line ``xAxisNumberFormat`` + ``yAxisNumberFormat``,
+# and Table ``columnFormatting[col].numberFormat`` have no prefix/suffix slots.
+# For those:
+#   - ``percentage`` is LEFT IN PLACE — the new multiply-by-100 semantic kicks
+#     in at render time. Values will change (e.g. an axis label of "50%" now
+#     renders as "5000%" if the underlying number was 50, or as "50%" if it
+#     was 0.5). Per product call: numbers may change; the format itself stays
+#     correct going forward.
+#   - ``currency`` must be migrated because the new NumberFormat Literal
+#     rejects it. It's demoted to ``default`` (loses ``$`` + grouping). No
+#     prefix slot exists to preserve the symbol on these surfaces.
+
+
+def _migrate_number_chart(cust: dict, log: list) -> None:
+    """Number chart — preserve old behavior via prefix/suffix companion fields."""
+    nf = cust.get("numberFormat")
+    if nf == "percentage":
+        cust["numberFormat"] = "default"
+        cust["numberSuffix"] = (cust.get("numberSuffix") or "") + "%"
+        log.append("numberFormat: percentage -> default + suffix '%'")
+    elif nf == "currency":
+        cust["numberFormat"] = "default"
+        cust["numberPrefix"] = "$" + (cust.get("numberPrefix") or "")
+        log.append("numberFormat: currency -> default + prefix '$'")
+
+
+def _migrate_currency_only(cust: dict, key: str, label_prefix: str, log: list) -> None:
+    """Migrate legacy ``currency`` at ``cust[key]`` to ``default``.
+
+    ``percentage`` is intentionally left in place on these axis / column slots
+    so the new multiply-by-100 semantic kicks in at render. No prefix slot
+    exists here to preserve the ``$`` for currency.
+    """
+    val = cust.get(key)
+    if val == "currency":
+        cust[key] = "default"
+        log.append(f"{label_prefix}{key}: currency -> default")
+
+
+def normalize_customizations(cust, chart_type: str) -> list:
+    """Mutate ``cust`` in place. Returns log entries describing what changed.
+
+    Idempotent: a re-run finds no remaining ``currency`` value and produces
+    no entries. ``percentage`` is intentionally left on non-Number paths.
+    """
+    if not isinstance(cust, dict):
+        return []
+    log: list = []
+
+    if chart_type == "number":
+        _migrate_number_chart(cust, log)
+    elif chart_type == "pie":
+        _migrate_currency_only(cust, "numberFormat", "", log)
+    elif chart_type in ("bar", "line"):
+        _migrate_currency_only(cust, "xAxisNumberFormat", "", log)
+        _migrate_currency_only(cust, "yAxisNumberFormat", "", log)
+    elif chart_type == "table":
+        col_fmt = cust.get("columnFormatting")
+        if isinstance(col_fmt, dict):
+            for col, col_cfg in col_fmt.items():
+                if isinstance(col_cfg, dict):
+                    _migrate_currency_only(
+                        col_cfg, "numberFormat", f"columnFormatting[{col}].", log
+                    )
+    # else: 'map' or unknown — no numberFormat to migrate
+
+    return log
+
+
+def walk_extra_config(extra_config, chart_type: str) -> list:
+    """Drill into ``extra_config.customizations`` and normalize. Returns log.
+
+    Returns empty list (and does nothing) when ``extra_config`` is not a dict
+    or ``customizations`` is missing / not a dict.
+    """
+    if not isinstance(extra_config, dict):
+        return []
+    cust = extra_config.get("customizations")
+    if not isinstance(cust, dict):
+        return []
+    log = normalize_customizations(cust, chart_type)
+    if log:
+        # Re-assign so the parent dict's reference picks up the mutation
+        extra_config["customizations"] = cust
+    return log
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Management command
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class Command(BaseCommand):
+    help = (
+        "Normalize legacy 'percentage'/'currency' numberFormat values on Chart "
+        "rows and inside ReportSnapshot.frozen_chart_configs."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print what would change without writing anything",
+        )
+        scope = parser.add_mutually_exclusive_group()
+        scope.add_argument(
+            "--charts-only",
+            action="store_true",
+            help="Only process Chart rows (skip ReportSnapshot)",
+        )
+        scope.add_argument(
+            "--snapshots-only",
+            action="store_true",
+            help="Only process ReportSnapshot rows (skip Chart)",
+        )
+
+    def handle(self, *args, **options):
+        dry_run: bool = options["dry_run"]
+        charts_only: bool = options["charts_only"]
+        snapshots_only: bool = options["snapshots_only"]
+
+        header = ("DRY RUN — " if dry_run else "") + (
+            "Normalizing legacy 'percentage'/'currency' numberFormat values"
+        )
+        self.stdout.write("")
+        self.stdout.write("=" * 72)
+        self.stdout.write(header)
+        self.stdout.write("=" * 72)
+
+        if not snapshots_only:
+            self._migrate_charts(dry_run=dry_run)
+        if not charts_only:
+            self._migrate_snapshots(dry_run=dry_run)
+
+        self.stdout.write("=" * 72)
+
+    # ── Charts ─────────────────────────────────────────────────────────
+
+    def _migrate_charts(self, *, dry_run: bool) -> None:
+        self.stdout.write("")
+        self.stdout.write("--- Charts ---")
+
+        per_type: dict = {"number": 0, "pie": 0, "bar": 0, "line": 0, "table": 0}
+        total = 0
+        to_save: list = []
+
+        for chart in Chart.objects.only("id", "title", "chart_type", "extra_config").iterator(
+            chunk_size=500
+        ):
+            cfg = chart.extra_config or {}
+            log = walk_extra_config(cfg, chart.chart_type or "")
+            if not log:
+                continue
+
+            total += 1
+            if chart.chart_type in per_type:
+                per_type[chart.chart_type] += 1
+
+            self.stdout.write(f"  Chart #{chart.id} ({chart.chart_type}) {chart.title!r}:")
+            for entry in log:
+                self.stdout.write(f"      - {entry}")
+
+            if not dry_run:
+                chart.extra_config = cfg
+                to_save.append(chart)
+
+        if not dry_run and to_save:
+            Chart.objects.bulk_update(to_save, ["extra_config"], batch_size=500)
+
+        verb = "would update" if dry_run else "updated"
+        self.stdout.write("")
+        if total:
+            self.stdout.write(self.style.SUCCESS(f"Charts {verb}: {total}"))
+            for ct, n in per_type.items():
+                if n:
+                    self.stdout.write(f"  - {ct}: {n}")
+        else:
+            self.stdout.write(self.style.SUCCESS(f"Charts {verb}: 0 (nothing to migrate)"))
+
+    # ── Report snapshots ───────────────────────────────────────────────
+
+    def _migrate_snapshots(self, *, dry_run: bool) -> None:
+        self.stdout.write("")
+        self.stdout.write("--- Report snapshots ---")
+
+        snap_total = 0
+        entity_total = 0
+        to_save: list = []
+
+        for snap in ReportSnapshot.objects.only("id", "title", "frozen_chart_configs").iterator(
+            chunk_size=500
+        ):
+            frozen = snap.frozen_chart_configs or {}
+            if not isinstance(frozen, dict):
+                continue
+
+            snap_log: list = []
+            for entity_id, frozen_cfg in frozen.items():
+                if not isinstance(frozen_cfg, dict):
+                    continue
+                ct = frozen_cfg.get("chart_type", "")
+                log = walk_extra_config(frozen_cfg.get("extra_config"), ct)
+                if log:
+                    frozen[entity_id] = frozen_cfg
+                    snap_log.append((entity_id, ct, log))
+
+            if not snap_log:
+                continue
+
+            snap_total += 1
+            entity_total += len(snap_log)
+
+            self.stdout.write(f"  Snapshot #{snap.id} {snap.title!r}:")
+            for entity_id, ct, log in snap_log:
+                self.stdout.write(f"      entity {entity_id} ({ct or 'unknown'}):")
+                for entry in log:
+                    self.stdout.write(f"          - {entry}")
+
+            if not dry_run:
+                snap.frozen_chart_configs = frozen
+                to_save.append(snap)
+
+        if not dry_run and to_save:
+            ReportSnapshot.objects.bulk_update(to_save, ["frozen_chart_configs"], batch_size=500)
+
+        verb = "would update" if dry_run else "updated"
+        self.stdout.write("")
+        if snap_total:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Snapshots {verb}: {snap_total} " f"({entity_total} frozen chart configs)"
+                )
+            )
+        else:
+            self.stdout.write(self.style.SUCCESS(f"Snapshots {verb}: 0 (nothing to migrate)"))

--- a/ddpui/migrations/0166_kpi_extra_config.py
+++ b/ddpui/migrations/0166_kpi_extra_config.py
@@ -1,0 +1,19 @@
+# Generated for KPI v1.1 — Number formatting & prefix/suffix
+# Adds `extra_config` JSONField to KPI. Backfills existing rows with {} via the
+# default=dict; no separate data-migration step needed.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ddpui", "0165_org_logo"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="kpi",
+            name="extra_config",
+            field=models.JSONField(default=dict),
+        ),
+    ]

--- a/ddpui/models/metric.py
+++ b/ddpui/models/metric.py
@@ -109,6 +109,11 @@ class KPI(models.Model):
 
     annotations = models.JSONField(default=list, blank=True)
 
+    # Display customizations (number format, prefix/suffix). Always a dict; never null.
+    # Nested as {"customizations": {"numberFormat": ..., "decimalPlaces": ...,
+    # "numberPrefix": ..., "numberSuffix": ...}}.
+    extra_config = models.JSONField(default=dict, blank=False, null=False)
+
     # Display order on KPI page
     display_order = models.IntegerField(default=0)
 

--- a/ddpui/schemas/chart_schemas/customizations.py
+++ b/ddpui/schemas/chart_schemas/customizations.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel, ConfigDict, Field
 NumberFormat = Literal[
     "default",
     "percentage",
-    "currency",
     "indian",
     "international",
     "european",

--- a/ddpui/schemas/kpi_schema.py
+++ b/ddpui/schemas/kpi_schema.py
@@ -4,10 +4,24 @@ from datetime import datetime
 from typing import Optional, List
 
 from ninja import Schema
+from pydantic import ConfigDict
 from ddpui.schemas.metric_schema import MetricResponse
+from ddpui.schemas.chart_schemas.customizations import NumberChartCustomizations
 
 
 # ── KPI Schemas ─────────────────────────────────────────────────────────────
+
+
+class KPIExtraConfig(Schema):
+    """Typed container for ``KPI.extra_config``.
+
+    ``extra_config`` itself is always a dict at DB + API layer (never null).
+    ``customizations`` inside is optional — clients MUST check before reading.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    customizations: Optional[NumberChartCustomizations] = None
 
 
 class KPICreate(Schema):
@@ -21,6 +35,7 @@ class KPICreate(Schema):
     time_dimension_column: Optional[str] = None
     metric_type_tag: Optional[str] = None
     program_tags: List[str] = []
+    extra_config: KPIExtraConfig  # required; clients always send {} or full payload
 
 
 class KPIUpdate(Schema):
@@ -35,6 +50,7 @@ class KPIUpdate(Schema):
     metric_type_tag: Optional[str] = None
     program_tags: Optional[List[str]] = None
     display_order: Optional[int] = None
+    extra_config: KPIExtraConfig  # required on every update
 
 
 class KPIResponse(Schema):
@@ -50,6 +66,7 @@ class KPIResponse(Schema):
     metric_type_tag: Optional[str]
     program_tags: List[str]
     display_order: int
+    extra_config: KPIExtraConfig  # always present — DB column has default=dict, null=False
     created_by: str  # creator's email
     created_at: datetime
     updated_at: datetime

--- a/ddpui/schemas/report_schema.py
+++ b/ddpui/schemas/report_schema.py
@@ -77,6 +77,10 @@ class FrozenKpiConfig(Schema):
     metric_type_tag: Optional[str] = None
     program_tags: List[str] = []
     periods: List[Dict[str, Any]] = []
+    # KPI display customizations (numberFormat, decimalPlaces, numberPrefix,
+    # numberSuffix) frozen at snapshot time. Defaults to {} for pre-v1.1
+    # snapshots — render path falls back to raw display in that case.
+    extra_config: Dict[str, Any] = {}
 
 
 # Request schemas

--- a/ddpui/tests/api_tests/test_kpi_api.py
+++ b/ddpui/tests/api_tests/test_kpi_api.py
@@ -22,7 +22,7 @@ from ddpui.api.kpi_api import (
     update_kpi,
     delete_kpi,
 )
-from ddpui.schemas.kpi_schema import KPICreate, KPIUpdate
+from ddpui.schemas.kpi_schema import KPICreate, KPIUpdate, KPIExtraConfig
 from ddpui.tests.api_tests.test_user_org_api import seed_db, mock_request
 
 pytestmark = pytest.mark.django_db
@@ -136,6 +136,7 @@ class TestCreateKPI:
             direction="increase",
             time_grain="monthly",
             target_value=500.0,
+            extra_config=KPIExtraConfig(),
         )
         response = create_kpi(request, payload)
         assert response.id is not None
@@ -149,6 +150,7 @@ class TestCreateKPI:
             metric_id=99999,
             direction="increase",
             time_grain="monthly",
+            extra_config=KPIExtraConfig(),
         )
         with pytest.raises(HttpError) as exc_info:
             create_kpi(request, payload)
@@ -160,6 +162,7 @@ class TestCreateKPI:
             metric_id=sample_metric.id,
             direction="sideways",
             time_grain="monthly",
+            extra_config=KPIExtraConfig(),
         )
         with pytest.raises(HttpError) as exc_info:
             create_kpi(request, payload)
@@ -184,14 +187,14 @@ class TestGetKPI:
 class TestUpdateKPI:
     def test_update_success(self, orguser, sample_kpi, seed_db):
         request = mock_request(orguser)
-        payload = KPIUpdate(name="Updated API KPI", target_value=2000.0)
+        payload = KPIUpdate(name="Updated API KPI", target_value=2000.0, extra_config=KPIExtraConfig())
         response = update_kpi(request, sample_kpi.id, payload)
         assert response.name == "Updated API KPI"
         assert response.target_value == 2000.0
 
     def test_update_not_found(self, orguser, seed_db):
         request = mock_request(orguser)
-        payload = KPIUpdate(name="Nope")
+        payload = KPIUpdate(name="Nope", extra_config=KPIExtraConfig())
         with pytest.raises(HttpError) as exc_info:
             update_kpi(request, 99999, payload)
         assert exc_info.value.status_code == 404

--- a/ddpui/tests/api_tests/test_kpi_api.py
+++ b/ddpui/tests/api_tests/test_kpi_api.py
@@ -187,7 +187,9 @@ class TestGetKPI:
 class TestUpdateKPI:
     def test_update_success(self, orguser, sample_kpi, seed_db):
         request = mock_request(orguser)
-        payload = KPIUpdate(name="Updated API KPI", target_value=2000.0, extra_config=KPIExtraConfig())
+        payload = KPIUpdate(
+            name="Updated API KPI", target_value=2000.0, extra_config=KPIExtraConfig()
+        )
         response = update_kpi(request, sample_kpi.id, payload)
         assert response.name == "Updated API KPI"
         assert response.target_value == 2000.0

--- a/ddpui/tests/core/alerts/test_rendering.py
+++ b/ddpui/tests/core/alerts/test_rendering.py
@@ -7,11 +7,16 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ddpui.settings")
 os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 django.setup()
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 from ddpui.core.alerts.rendering import (
     TOKENS_BY_TYPE,
     render,
     resolve_tokens,
+    tokens_for_alert,
 )
+from ddpui.models.alert import AlertType
 
 
 # ── render() ────────────────────────────────────────────────────────────────
@@ -113,3 +118,148 @@ def test_tokens_by_type_constants_match_frontend_expectations():
         "target_value",
         "current_value",
     ]
+
+
+# ── tokens_for_alert: kpi_rag formatting via customizations ─────────────────
+
+
+def _kpi_rag_alert(*, extra_config: dict, target_value=10000, kpi_name="Signups"):
+    """Build a minimal Alert mock with a kpi_rag type and an attached KPI."""
+    kpi = SimpleNamespace(
+        name=kpi_name,
+        target_value=target_value,
+        extra_config=extra_config,
+    )
+    alert = MagicMock()
+    alert.alert_type = AlertType.KPI_RAG
+    alert.name = "Signups RAG"
+    alert.kpi_id = 42
+    alert.kpi = kpi
+    alert.metric_id = None
+    alert.metric = None
+    alert.standalone_config = None
+    alert.condition = {}
+    return alert
+
+
+def test_kpi_rag_formats_current_and_target_with_customizations():
+    """numberFormat='indian' + prefix='₹' → both values use Indian grouping + ₹."""
+    alert = _kpi_rag_alert(
+        extra_config={
+            "customizations": {
+                "numberFormat": "indian",
+                "decimalPlaces": 0,
+                "numberPrefix": "₹",
+                "numberSuffix": "",
+            }
+        },
+        target_value=1234567,
+    )
+    tokens = tokens_for_alert(alert, current_value=987654, rag_status="amber")
+    assert tokens["current_value"] == "₹9,87,654"
+    assert tokens["target_value"] == "₹12,34,567"
+    assert tokens["rag_status"] == "amber"
+
+
+def test_kpi_rag_percentage_format_multiplies_by_100():
+    """numberFormat='percentage' → multiplies by 100, appends '%'."""
+    alert = _kpi_rag_alert(
+        extra_config={"customizations": {"numberFormat": "percentage", "decimalPlaces": 2}},
+        target_value=1.0,
+    )
+    tokens = tokens_for_alert(alert, current_value=0.855, rag_status="green")
+    assert tokens["current_value"] == "85.50%"
+    assert tokens["target_value"] == "100.00%"
+
+
+def test_kpi_rag_no_customizations_leaves_values_raw():
+    """No extra_config → values pass through untouched (raw number)."""
+    alert = _kpi_rag_alert(extra_config={}, target_value=10000)
+    tokens = tokens_for_alert(alert, current_value=9500)
+    # Raw int — render() will str() it at substitution time
+    assert tokens["current_value"] == 9500
+    assert tokens["target_value"] == 10000
+
+
+def test_kpi_rag_customizations_without_numberFormat_leaves_values_raw():
+    """extra_config.customizations present but no numberFormat → no formatting
+    (matches frontend formatKPIValue's String(value) fallback)."""
+    alert = _kpi_rag_alert(
+        extra_config={"customizations": {"decimalPlaces": 2}},
+        target_value=10000,
+    )
+    tokens = tokens_for_alert(alert, current_value=9500)
+    assert tokens["current_value"] == 9500
+    assert tokens["target_value"] == 10000
+
+
+def test_kpi_rag_none_current_value_preserved_for_unresolved_token():
+    """A None current_value must stay None so render() leaves {{current_value}}
+    unresolved (avoids rendering literal 'No data' into email bodies)."""
+    alert = _kpi_rag_alert(
+        extra_config={"customizations": {"numberFormat": "indian"}},
+        target_value=10000,
+    )
+    tokens = tokens_for_alert(alert, current_value=None, rag_status="red")
+    assert tokens["current_value"] is None
+    # Target still formats because it isn't None
+    assert tokens["target_value"] == "10,000"
+
+
+def test_kpi_rag_with_existing_prefix_suffix_combination():
+    """Customizations combining prefix + suffix produce both in the token."""
+    alert = _kpi_rag_alert(
+        extra_config={
+            "customizations": {
+                "numberFormat": "default",
+                "decimalPlaces": 0,
+                "numberPrefix": "",
+                "numberSuffix": " users",
+            }
+        },
+        target_value=1000,
+    )
+    tokens = tokens_for_alert(alert, current_value=857)
+    assert tokens["current_value"] == "857 users"
+    assert tokens["target_value"] == "1000 users"
+
+
+def test_metric_threshold_alert_unaffected_by_kpi_formatting_path():
+    """Non-kpi_rag alerts must not run the KPI formatting branch even if a KPI
+    is somehow attached. The current_value stays raw."""
+    alert = MagicMock()
+    alert.alert_type = AlertType.METRIC_THRESHOLD
+    alert.name = "Metric alert"
+    alert.metric_id = 1
+    alert.metric = SimpleNamespace(name="Active users")
+    alert.kpi_id = None
+    alert.kpi = None
+    alert.standalone_config = None
+    alert.condition = {"value": 100}
+    tokens = tokens_for_alert(alert, current_value=42)
+    # Raw — no format_number_v2 applied
+    assert tokens["current_value"] == 42
+    assert tokens["target_value"] == 100
+    assert tokens["metric_name"] == "Active users"
+
+
+def test_kpi_rag_end_to_end_render_matches_card_format():
+    """End-to-end: tokens_for_alert + render() yields an email body that
+    matches the KPI card render byte-for-byte."""
+    alert = _kpi_rag_alert(
+        extra_config={
+            "customizations": {
+                "numberFormat": "indian",
+                "decimalPlaces": 0,
+                "numberPrefix": "₹",
+                "numberSuffix": "",
+            }
+        },
+        target_value=200000,
+    )
+    tokens = tokens_for_alert(alert, current_value=123456, rag_status="amber")
+    body = render(
+        "{{kpi_name}} is at {{current_value}} (target {{target_value}}, {{rag_status}})",
+        tokens,
+    )
+    assert body == "Signups is at ₹1,23,456 (target ₹2,00,000, amber)"

--- a/ddpui/tests/core/charts/test_legacy_number_format_normalizer.py
+++ b/ddpui/tests/core/charts/test_legacy_number_format_normalizer.py
@@ -1,0 +1,217 @@
+"""Unit tests for the module-level helpers inside the
+``migrate_legacy_number_formats`` management command.
+"""
+
+from __future__ import annotations
+
+from ddpui.management.commands.migrate_legacy_number_formats import (
+    normalize_customizations,
+    walk_extra_config,
+)
+
+
+# ── Number chart: full preservation via numberPrefix / numberSuffix ────────
+
+
+class TestNumberChartPreservation:
+    def test_percentage_appends_to_suffix(self):
+        cust = {"numberFormat": "percentage"}
+        log = normalize_customizations(cust, "number")
+        assert cust["numberFormat"] == "default"
+        assert cust["numberSuffix"] == "%"
+        assert log == ["numberFormat: percentage -> default + suffix '%'"]
+
+    def test_percentage_preserves_existing_suffix(self):
+        cust = {"numberFormat": "percentage", "numberSuffix": " of total"}
+        normalize_customizations(cust, "number")
+        assert cust["numberSuffix"] == " of total%"
+
+    def test_currency_prepends_to_prefix(self):
+        cust = {"numberFormat": "currency"}
+        log = normalize_customizations(cust, "number")
+        assert cust["numberFormat"] == "default"
+        assert cust["numberPrefix"] == "$"
+        assert log == ["numberFormat: currency -> default + prefix '$'"]
+
+    def test_currency_preserves_existing_prefix(self):
+        cust = {"numberFormat": "currency", "numberPrefix": "Rs "}
+        normalize_customizations(cust, "number")
+        assert cust["numberPrefix"] == "$Rs "
+
+    def test_other_formats_untouched(self):
+        cust = {"numberFormat": "indian", "decimalPlaces": 2}
+        assert normalize_customizations(cust, "number") == []
+        assert cust == {"numberFormat": "indian", "decimalPlaces": 2}
+
+    def test_no_number_format_key_is_noop(self):
+        cust = {"decimalPlaces": 2, "numberPrefix": "₹"}
+        assert normalize_customizations(cust, "number") == []
+        assert cust == {"decimalPlaces": 2, "numberPrefix": "₹"}
+
+
+# ── Pie chart: currency-only migration ─────────────────────────────────────
+#
+# Percentage is intentionally LEFT IN PLACE on the pie chart's numberFormat
+# slot. The new multiply-by-100 semantic kicks in at render time; values may
+# change visually but the format itself remains "percentage".
+
+
+class TestPieChartCurrencyOnly:
+    def test_percentage_left_in_place(self):
+        cust = {"numberFormat": "percentage", "decimalPlaces": 1}
+        log = normalize_customizations(cust, "pie")
+        # Untouched — new multiply-by-100 semantic kicks in at render.
+        assert cust["numberFormat"] == "percentage"
+        assert log == []
+
+    def test_currency_demoted(self):
+        cust = {"numberFormat": "currency"}
+        log = normalize_customizations(cust, "pie")
+        assert cust["numberFormat"] == "default"
+        assert "numberPrefix" not in cust  # no prefix slot on PieChartCustomizations
+        assert log == ["numberFormat: currency -> default"]
+
+    def test_pie_label_format_percentage_untouched(self):
+        # Pie's labelFormat='percentage' is a SEPARATE field (slice label
+        # rendering — show "%" share). Must not be touched.
+        cust = {"labelFormat": "percentage", "numberFormat": "indian"}
+        normalize_customizations(cust, "pie")
+        assert cust["labelFormat"] == "percentage"
+
+
+# ── Bar / Line: two axis fields ────────────────────────────────────────────
+
+
+class TestBarLineAxis:
+    def test_currency_axis_demoted_percentage_axis_left(self):
+        cust = {"xAxisNumberFormat": "percentage", "yAxisNumberFormat": "currency"}
+        log = normalize_customizations(cust, "bar")
+        # percentage stays put — new multiply-by-100 semantic kicks in
+        assert cust["xAxisNumberFormat"] == "percentage"
+        assert cust["yAxisNumberFormat"] == "default"
+        assert log == ["yAxisNumberFormat: currency -> default"]
+
+    def test_percentage_axes_untouched(self):
+        cust = {"xAxisNumberFormat": "percentage", "yAxisNumberFormat": "percentage"}
+        log = normalize_customizations(cust, "line")
+        assert cust["xAxisNumberFormat"] == "percentage"
+        assert cust["yAxisNumberFormat"] == "percentage"
+        assert log == []
+
+    def test_top_level_numberFormat_on_bar_untouched(self):
+        # Bar uses axis-level keys, not top-level numberFormat.
+        cust = {"numberFormat": "percentage"}
+        log = normalize_customizations(cust, "bar")
+        assert cust["numberFormat"] == "percentage"
+        assert log == []
+
+
+# ── Table: per-column nested ───────────────────────────────────────────────
+
+
+class TestTableColumnFormatting:
+    def test_currency_demoted_percentage_left(self):
+        cust = {
+            "columnFormatting": {
+                "revenue": {"numberFormat": "currency", "decimalPlaces": 2},
+                "growth": {"numberFormat": "percentage"},
+                "count": {"numberFormat": "indian"},
+            }
+        }
+        log = normalize_customizations(cust, "table")
+        assert cust["columnFormatting"]["revenue"]["numberFormat"] == "default"
+        # percentage stays put — new multiply-by-100 semantic kicks in
+        assert cust["columnFormatting"]["growth"]["numberFormat"] == "percentage"
+        assert cust["columnFormatting"]["count"]["numberFormat"] == "indian"
+        # Decimal places preserved on the migrated row
+        assert cust["columnFormatting"]["revenue"]["decimalPlaces"] == 2
+        assert log == ["columnFormatting[revenue].numberFormat: currency -> default"]
+
+    def test_empty_column_formatting(self):
+        cust = {"columnFormatting": {}}
+        assert normalize_customizations(cust, "table") == []
+
+    def test_no_column_formatting_key(self):
+        cust = {"dateColumnFormatting": {}}
+        assert normalize_customizations(cust, "table") == []
+
+    def test_malformed_column_entry_skipped(self):
+        cust = {"columnFormatting": {"col": "not-a-dict", "ok": {"numberFormat": "currency"}}}
+        log = normalize_customizations(cust, "table")
+        assert cust["columnFormatting"]["col"] == "not-a-dict"
+        assert cust["columnFormatting"]["ok"]["numberFormat"] == "default"
+        assert log == ["columnFormatting[ok].numberFormat: currency -> default"]
+
+
+# ── Map + unknown chart types ──────────────────────────────────────────────
+
+
+class TestUnhandledTypes:
+    def test_map_returns_empty(self):
+        cust = {"colorScheme": "Blues"}
+        assert normalize_customizations(cust, "map") == []
+
+    def test_unknown_chart_type_returns_empty(self):
+        # Unknown type — value untouched (intentional: only handled types
+        # get migrated, others stay raw).
+        cust = {"numberFormat": "percentage"}
+        assert normalize_customizations(cust, "future-chart-type") == []
+        assert cust["numberFormat"] == "percentage"
+
+
+# ── Defensive: bad inputs don't crash ──────────────────────────────────────
+
+
+class TestDefensive:
+    def test_none_customizations(self):
+        assert normalize_customizations(None, "number") == []
+
+    def test_non_dict_customizations(self):
+        assert normalize_customizations("oops", "number") == []
+        assert normalize_customizations([], "number") == []
+        assert normalize_customizations(42, "number") == []
+
+    def test_walk_handles_none_extra_config(self):
+        assert walk_extra_config(None, "number") == []
+
+    def test_walk_handles_missing_customizations(self):
+        assert walk_extra_config({"unrelated": "value"}, "number") == []
+
+    def test_walk_handles_non_dict_customizations(self):
+        assert walk_extra_config({"customizations": "oops"}, "number") == []
+
+
+# ── Idempotency ────────────────────────────────────────────────────────────
+
+
+class TestIdempotency:
+    def test_re_running_is_noop_for_number(self):
+        cust = {"numberFormat": "percentage"}
+        normalize_customizations(cust, "number")
+        first_snapshot = dict(cust)
+        log = normalize_customizations(cust, "number")
+        assert log == []
+        assert cust == first_snapshot
+
+    def test_re_running_is_noop_for_table(self):
+        cust = {"columnFormatting": {"x": {"numberFormat": "currency"}}}
+        normalize_customizations(cust, "table")
+        first_snapshot = {"columnFormatting": dict(cust["columnFormatting"])}
+        log = normalize_customizations(cust, "table")
+        assert log == []
+        assert cust == first_snapshot
+
+
+# ── walk_extra_config integration ──────────────────────────────────────────
+
+
+class TestWalkExtraConfig:
+    def test_writes_back_to_extra_config(self):
+        extra = {
+            "metrics": [{"column": "x"}],
+            "customizations": {"numberFormat": "percentage"},
+        }
+        log = walk_extra_config(extra, "number")
+        assert extra["customizations"]["numberFormat"] == "default"
+        assert extra["customizations"]["numberSuffix"] == "%"
+        assert log

--- a/ddpui/tests/core/charts/test_number_formatting.py
+++ b/ddpui/tests/core/charts/test_number_formatting.py
@@ -1,0 +1,205 @@
+"""Tests for ``ddpui.core.charts.number_formatting.format_number_v2``.
+
+These tests lock the backend formatter's output for every supported format type
+and edge case. A separate cross-stack parity fixture
+(``tests/fixtures/number_format_parity.json``) ensures the frontend
+``formatNumber`` produces byte-identical output for the same inputs.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from ddpui.core.charts.number_formatting import format_number_v2
+
+
+# ── Null / NaN / Infinity ──────────────────────────────────────────────────
+
+
+class TestNullAndNonFinite:
+    @pytest.mark.parametrize("bad", [None, float("nan"), float("inf"), float("-inf")])
+    def test_returns_no_data(self, bad):
+        assert format_number_v2(bad) == "No data"
+
+    def test_no_data_ignores_prefix_suffix(self):
+        # prefix/suffix should NOT wrap "No data" — that would render as e.g. "₹No data%"
+        assert format_number_v2(None, "indian", 2, "₹", "%") == "No data"
+
+
+# ── default ────────────────────────────────────────────────────────────────
+
+
+class TestDefault:
+    def test_integer_no_decimals(self):
+        assert format_number_v2(42, "default", 0) == "42"
+
+    def test_float_with_decimals(self):
+        assert format_number_v2(3.14159, "default", 2) == "3.14"
+
+    def test_zero_no_decimals(self):
+        assert format_number_v2(0, "default", 0) == "0"
+
+    def test_negative(self):
+        assert format_number_v2(-123, "default", 0) == "-123"
+
+    def test_unknown_format_falls_back_to_default(self):
+        assert format_number_v2(42, "wild-and-crazy", 0) == "42"
+
+
+# ── percentage ─────────────────────────────────────────────────────────────
+
+
+class TestPercentage:
+    def test_zero_decimals(self):
+        assert format_number_v2(85, "percentage", 0) == "85%"
+
+    def test_two_decimals(self):
+        assert format_number_v2(85.5, "percentage", 2) == "85.50%"
+
+
+# ── currency ───────────────────────────────────────────────────────────────
+
+
+class TestCurrency:
+    def test_no_decimals(self):
+        assert format_number_v2(1234, "currency", 0) == "$1,234"
+
+    def test_two_decimals(self):
+        assert format_number_v2(1234.5, "currency", 2) == "$1,234.50"
+
+
+# ── international (en_US grouping) ─────────────────────────────────────────
+
+
+class TestInternational:
+    def test_million_no_decimals(self):
+        assert format_number_v2(1_000_000, "international", 0) == "1,000,000"
+
+    def test_decimals(self):
+        assert format_number_v2(1234567.89, "international", 2) == "1,234,567.89"
+
+
+# ── indian (lakh / crore grouping) ─────────────────────────────────────────
+
+
+class TestIndian:
+    def test_six_digits(self):
+        # 1,23,456 — Indian lakh grouping
+        assert format_number_v2(123456, "indian", 0) == "1,23,456"
+
+    def test_crore(self):
+        # 1,23,45,678 — Indian crore grouping
+        assert format_number_v2(12345678, "indian", 0) == "1,23,45,678"
+
+    def test_decimals(self):
+        assert format_number_v2(123456.789, "indian", 2) == "1,23,456.79"
+
+
+# ── european (de_DE: dot-thousands, comma-decimal) ─────────────────────────
+
+
+class TestEuropean:
+    def test_thousand_no_decimals(self):
+        assert format_number_v2(1234, "european", 0) == "1.234"
+
+    def test_decimals(self):
+        assert format_number_v2(1234.56, "european", 2) == "1.234,56"
+
+
+# ── adaptive_international (K / M / B) ─────────────────────────────────────
+
+
+class TestAdaptiveInternational:
+    def test_under_thousand(self):
+        # below 1k threshold — no compact suffix; default 2 decimals not applied
+        # for the small-number path (matches frontend logic)
+        assert format_number_v2(500, "adaptive_international", 0) == "500"
+
+    def test_thousand(self):
+        assert format_number_v2(1500, "adaptive_international", 2) == "1.50K"
+
+    def test_million(self):
+        assert format_number_v2(2_500_000, "adaptive_international", 2) == "2.50M"
+
+    def test_billion(self):
+        assert format_number_v2(1_200_000_000, "adaptive_international", 1) == "1.2B"
+
+    def test_negative(self):
+        assert format_number_v2(-2_500_000, "adaptive_international", 1) == "-2.5M"
+
+
+# ── adaptive_indian (K / L / Cr) ───────────────────────────────────────────
+
+
+class TestAdaptiveIndian:
+    def test_thousand(self):
+        assert format_number_v2(1500, "adaptive_indian", 2) == "1.50K"
+
+    def test_lakh(self):
+        # 1 lakh = 100,000
+        assert format_number_v2(150_000, "adaptive_indian", 2) == "1.50L"
+
+    def test_crore(self):
+        # 1 crore = 10,000,000
+        assert format_number_v2(12_500_000, "adaptive_indian", 2) == "1.25Cr"
+
+
+# ── prefix / suffix wrapping ───────────────────────────────────────────────
+
+
+class TestPrefixSuffix:
+    def test_prefix_only(self):
+        assert format_number_v2(1234, "indian", 0, prefix="₹") == "₹1,234"
+
+    def test_suffix_only(self):
+        assert format_number_v2(85, "default", 0, suffix=" people") == "85 people"
+
+    def test_prefix_and_suffix(self):
+        assert format_number_v2(1234, "indian", 0, prefix="₹", suffix=" total") == "₹1,234 total"
+
+    def test_currency_prefix_combines_with_user_prefix(self):
+        # currency adds its own "$"; user prefix wraps on the outside
+        # (e.g. user prefix "USD " → "USD $1,234")
+        assert format_number_v2(1234, "currency", 0, prefix="USD ") == "USD $1,234"
+
+
+# ── decimal-place clamping (mirrors frontend MAX_DECIMAL_PLACES=10 / min 0) ─
+
+
+class TestDecimalClamping:
+    def test_negative_decimals_clamped_to_zero(self):
+        # Negative decimal_places shouldn't crash. Clamped to 0; under the
+        # `default` format that means "no rounding" — preserves the legacy
+        # ``EChartsConfigGenerator._format_number`` behavior for back-compat
+        # with existing number-chart consumers.
+        assert format_number_v2(1234.5678, "default", -3) == "1234.5678"
+
+    def test_over_max_decimals_clamped(self):
+        # 25 → clamps to 10
+        result = format_number_v2(1.123456789012345, "default", 25)
+        # exactly 10 decimal places
+        assert result.split(".")[1] == "1234567890"
+
+
+# ── integration: matches existing _format_number behavior ──────────────────
+
+
+class TestBackwardCompatWithEChartsGenerator:
+    """The old ``EChartsConfigGenerator._format_number`` now delegates to
+    ``format_number_v2``. These tests pin the output for the three formats it
+    handled before (default / percentage / currency) so the delegation is
+    behavior-preserving for existing chart consumers."""
+
+    def test_default_int(self):
+        assert format_number_v2(100, "default", 0) == "100"
+
+    def test_default_float_with_decimals(self):
+        assert format_number_v2(99.5, "default", 1) == "99.5"
+
+    def test_percentage(self):
+        assert format_number_v2(50.5, "percentage", 2) == "50.50%"
+
+    def test_currency(self):
+        assert format_number_v2(1000, "currency", 2) == "$1,000.00"

--- a/ddpui/tests/core/charts/test_number_formatting.py
+++ b/ddpui/tests/core/charts/test_number_formatting.py
@@ -48,26 +48,24 @@ class TestDefault:
         assert format_number_v2(42, "wild-and-crazy", 0) == "42"
 
 
-# ── percentage ─────────────────────────────────────────────────────────────
+# ── percentage (value is a ratio — multiply by 100) ────────────────────────
 
 
 class TestPercentage:
-    def test_zero_decimals(self):
-        assert format_number_v2(85, "percentage", 0) == "85%"
+    def test_ratio_zero_decimals(self):
+        assert format_number_v2(0.85, "percentage", 0) == "85%"
 
-    def test_two_decimals(self):
-        assert format_number_v2(85.5, "percentage", 2) == "85.50%"
+    def test_ratio_two_decimals(self):
+        assert format_number_v2(0.855, "percentage", 2) == "85.50%"
 
+    def test_one_renders_as_hundred(self):
+        assert format_number_v2(1, "percentage", 0) == "100%"
 
-# ── currency ───────────────────────────────────────────────────────────────
+    def test_negative_ratio(self):
+        assert format_number_v2(-0.25, "percentage", 1) == "-25.0%"
 
-
-class TestCurrency:
-    def test_no_decimals(self):
-        assert format_number_v2(1234, "currency", 0) == "$1,234"
-
-    def test_two_decimals(self):
-        assert format_number_v2(1234.5, "currency", 2) == "$1,234.50"
+    def test_zero(self):
+        assert format_number_v2(0, "percentage", 2) == "0.00%"
 
 
 # ── international (en_US grouping) ─────────────────────────────────────────
@@ -159,11 +157,6 @@ class TestPrefixSuffix:
     def test_prefix_and_suffix(self):
         assert format_number_v2(1234, "indian", 0, prefix="₹", suffix=" total") == "₹1,234 total"
 
-    def test_currency_prefix_combines_with_user_prefix(self):
-        # currency adds its own "$"; user prefix wraps on the outside
-        # (e.g. user prefix "USD " → "USD $1,234")
-        assert format_number_v2(1234, "currency", 0, prefix="USD ") == "USD $1,234"
-
 
 # ── decimal-place clamping (mirrors frontend MAX_DECIMAL_PLACES=10 / min 0) ─
 
@@ -187,10 +180,10 @@ class TestDecimalClamping:
 
 
 class TestBackwardCompatWithEChartsGenerator:
-    """The old ``EChartsConfigGenerator._format_number`` now delegates to
-    ``format_number_v2``. These tests pin the output for the three formats it
-    handled before (default / percentage / currency) so the delegation is
-    behavior-preserving for existing chart consumers."""
+    """The old ``EChartsConfigGenerator._format_number`` delegates to
+    ``format_number_v2``. These tests pin the output for the two formats it
+    still supports (default / percentage) — note that percentage semantics
+    changed in v1.1: value is now treated as a ratio (0.85 → 85.00%)."""
 
     def test_default_int(self):
         assert format_number_v2(100, "default", 0) == "100"
@@ -198,8 +191,8 @@ class TestBackwardCompatWithEChartsGenerator:
     def test_default_float_with_decimals(self):
         assert format_number_v2(99.5, "default", 1) == "99.5"
 
-    def test_percentage(self):
-        assert format_number_v2(50.5, "percentage", 2) == "50.50%"
-
-    def test_currency(self):
-        assert format_number_v2(1000, "currency", 2) == "$1,000.00"
+    def test_percentage_ratio_semantics(self):
+        # New semantics: multiplies by 100. A legacy chart that stored raw
+        # percentages (e.g. 50) needs to be migrated to ratio form (0.50) or
+        # to numberFormat="default" + numberSuffix="%".
+        assert format_number_v2(0.505, "percentage", 2) == "50.50%"

--- a/ddpui/tests/core/reports/test_report_service.py
+++ b/ddpui/tests/core/reports/test_report_service.py
@@ -1410,6 +1410,48 @@ class TestFreezeKpiConfigs:
 
         assert kpi_data["periods"] == []
 
+    def test_kpi_extra_config_frozen_with_customizations(
+        self, mock_kpi_service, mock_org_wh, kpi_dashboard, sample_kpi
+    ):
+        """Customizations on the live KPI are copied into the frozen blob."""
+        mock_org_wh.objects.filter.return_value.first.return_value = None
+        sample_kpi.extra_config = {
+            "customizations": {
+                "numberFormat": "indian",
+                "decimalPlaces": 0,
+                "numberPrefix": "₹",
+                "numberSuffix": "",
+            }
+        }
+        sample_kpi.save(update_fields=["extra_config"])
+
+        frozen = ReportService._freeze_chart_configs(kpi_dashboard)
+        kpi_data = frozen[str(sample_kpi.id)]
+
+        assert kpi_data["extra_config"] == {
+            "customizations": {
+                "numberFormat": "indian",
+                "decimalPlaces": 0,
+                "numberPrefix": "₹",
+                "numberSuffix": "",
+            }
+        }
+
+    def test_kpi_extra_config_frozen_empty_for_pre_v11_kpi(
+        self, mock_kpi_service, mock_org_wh, kpi_dashboard, sample_kpi
+    ):
+        """A KPI with no customizations freezes extra_config as {} —
+        snapshots taken before v1.1 render with no formatting."""
+        mock_org_wh.objects.filter.return_value.first.return_value = None
+        # sample_kpi fixture creates the row without customizations → JSONField
+        # default = {}, simulating a pre-v1.1 KPI.
+        assert sample_kpi.extra_config == {}
+
+        frozen = ReportService._freeze_chart_configs(kpi_dashboard)
+        kpi_data = frozen[str(sample_kpi.id)]
+
+        assert kpi_data["extra_config"] == {}
+
     def test_kpi_only_dashboard(self, mock_kpi_service, mock_org_wh, orguser, org, sample_kpi):
         """Dashboard with only KPI components (no charts)"""
         mock_org_wh.objects.filter.return_value.first.return_value = None
@@ -1611,6 +1653,64 @@ class TestGetReportKpiData:
 
         snapshot.delete()
         f.delete()
+        dashboard.delete()
+
+    @patch("ddpui.core.kpi.kpi_service.KPIService.compute_kpi_data")
+    def test_snapshot_uses_frozen_customizations_not_live(
+        self, mock_compute, orguser, org, sample_kpi
+    ):
+        """Editing the KPI's customizations AFTER snapshot must not affect the
+        snapshot — the snapshot reads from frozen extra_config."""
+        sample_kpi.extra_config = {
+            "customizations": {
+                "numberFormat": "indian",
+                "decimalPlaces": 0,
+                "numberPrefix": "₹",
+                "numberSuffix": "",
+            }
+        }
+        sample_kpi.save(update_fields=["extra_config"])
+
+        dashboard = Dashboard.objects.create(
+            title="Frozen Cust Test",
+            dashboard_type="native",
+            grid_columns=12,
+            tabs=[
+                {
+                    "id": "tab-1",
+                    "title": "T",
+                    "components": {
+                        "kpi-1": {"type": "kpi", "config": {"kpiId": sample_kpi.id}},
+                    },
+                }
+            ],
+            created_by=orguser,
+            org=org,
+        )
+        snapshot = ReportService.create_snapshot(
+            title="Frozen Cust Report",
+            dashboard_id=dashboard.id,
+            date_column={},
+            period_end=date(2025, 3, 31),
+            orguser=orguser,
+        )
+
+        # Now mutate the live KPI's customizations — snapshot should be unaffected.
+        sample_kpi.extra_config = {
+            "customizations": {"numberFormat": "european", "decimalPlaces": 2}
+        }
+        sample_kpi.save(update_fields=["extra_config"])
+
+        mock_compute.return_value = {"data": {}, "echarts_config": {}}
+        ReportService.get_report_kpi_data(snapshot.id, sample_kpi.id, org)
+
+        kpi_response = mock_compute.call_args[0][0]
+        # KPIResponse built from the FROZEN config — original 'indian' format
+        assert kpi_response.extra_config.customizations is not None
+        assert kpi_response.extra_config.customizations.numberFormat == "indian"
+        assert kpi_response.extra_config.customizations.numberPrefix == "₹"
+
+        snapshot.delete()
         dashboard.delete()
 
     @patch("ddpui.core.kpi.kpi_service.KPIService.compute_kpi_data")

--- a/ddpui/tests/schema_tests/test_chart_schema.py
+++ b/ddpui/tests/schema_tests/test_chart_schema.py
@@ -881,7 +881,7 @@ class TestTypedCustomizations:
 
     def test_number_customizations_extras_pass_through(self):
         """UI may add fields like prefix/suffix; those should survive."""
-        chart = self._number(numberFormat="currency", prefix="$", suffix="")
+        chart = self._number(numberFormat="international", prefix="$", suffix="")
         dumped = chart.extra_config.customizations.model_dump()
         assert dumped["prefix"] == "$"
 

--- a/ddpui/tests/services/test_kpi_service.py
+++ b/ddpui/tests/services/test_kpi_service.py
@@ -16,7 +16,7 @@ from ddpui.models.role_based_access import Role
 from ddpui.models.metric import Metric, KPI
 from ddpui.models.dashboard import Dashboard
 from ddpui.auth import ACCOUNT_MANAGER_ROLE
-from ddpui.schemas.kpi_schema import KPICreate, KPIUpdate
+from ddpui.schemas.kpi_schema import KPICreate, KPIUpdate, KPIExtraConfig
 from ddpui.core.kpi.kpi_service import (
     KPIService,
     KPINotFoundError,
@@ -158,13 +158,63 @@ class TestKPICRUD:
             direction="increase",
             time_grain="monthly",
             target_value=500.0,
+            extra_config=KPIExtraConfig(),
         )
         kpi = KPIService.create_kpi(payload, orguser)
         assert kpi.id is not None
         assert kpi.name == sample_metric.name  # defaults to metric name
         assert kpi.target_value == 500.0
         assert kpi.direction == "increase"
+        # extra_config defaults to {} on the model — never null
+        assert kpi.extra_config == {"customizations": None}
         kpi.delete()
+
+    def test_create_kpi_with_customizations(self, orguser, sample_metric, seed_db):
+        """v1.1: KPICreate accepts and persists number-format customizations."""
+        from ddpui.schemas.chart_schemas.customizations import NumberChartCustomizations
+
+        payload = KPICreate(
+            metric_id=sample_metric.id,
+            direction="increase",
+            time_grain="monthly",
+            target_value=500.0,
+            extra_config=KPIExtraConfig(
+                customizations=NumberChartCustomizations(
+                    numberFormat="indian",
+                    decimalPlaces=0,
+                    numberPrefix="₹",
+                    numberSuffix="",
+                )
+            ),
+        )
+        kpi = KPIService.create_kpi(payload, orguser)
+        c = kpi.extra_config["customizations"]
+        assert c["numberFormat"] == "indian"
+        assert c["decimalPlaces"] == 0
+        assert c["numberPrefix"] == "₹"
+
+        # Round-trip through kpi_to_response — customizations survives the
+        # Pydantic → dict → Pydantic conversion
+        response = KPIService.kpi_to_response(kpi)
+        assert response.extra_config.customizations.numberFormat == "indian"
+        assert response.extra_config.customizations.numberPrefix == "₹"
+        kpi.delete()
+
+    def test_update_kpi_replaces_customizations(self, orguser, org, sample_kpi, seed_db):
+        """Updating a KPI with a new customizations payload replaces the stored config."""
+        from ddpui.schemas.chart_schemas.customizations import NumberChartCustomizations
+
+        payload = KPIUpdate(
+            name="Updated",
+            extra_config=KPIExtraConfig(
+                customizations=NumberChartCustomizations(
+                    numberFormat="adaptive_indian", decimalPlaces=2
+                )
+            ),
+        )
+        updated = KPIService.update_kpi(sample_kpi.id, org, orguser, payload)
+        assert updated.extra_config["customizations"]["numberFormat"] == "adaptive_indian"
+        assert updated.extra_config["customizations"]["decimalPlaces"] == 2
 
     def test_create_kpi_custom_name(self, orguser, sample_metric, seed_db):
         payload = KPICreate(
@@ -174,6 +224,7 @@ class TestKPICRUD:
             time_grain="quarterly",
             green_threshold_pct=80.0,
             amber_threshold_pct=110.0,
+            extra_config=KPIExtraConfig(),
         )
         kpi = KPIService.create_kpi(payload, orguser)
         assert kpi.name == "Custom KPI Name"
@@ -186,6 +237,7 @@ class TestKPICRUD:
             metric_id=sample_metric.id,
             direction="sideways",
             time_grain="monthly",
+            extra_config=KPIExtraConfig(),
         )
         with pytest.raises(KPIValidationError, match="Invalid direction"):
             KPIService.create_kpi(payload, orguser)
@@ -195,6 +247,7 @@ class TestKPICRUD:
             metric_id=sample_metric.id,
             direction="increase",
             time_grain="hourly",
+            extra_config=KPIExtraConfig(),
         )
         with pytest.raises(KPIValidationError, match="Invalid time_grain"):
             KPIService.create_kpi(payload, orguser)
@@ -206,6 +259,7 @@ class TestKPICRUD:
             time_grain="monthly",
             green_threshold_pct=50.0,
             amber_threshold_pct=80.0,
+            extra_config=KPIExtraConfig(),
         )
         with pytest.raises(KPIValidationError, match="green_threshold_pct"):
             KPIService.create_kpi(payload, orguser)
@@ -217,6 +271,7 @@ class TestKPICRUD:
             time_grain="monthly",
             green_threshold_pct=80.0,
             amber_threshold_pct=50.0,
+            extra_config=KPIExtraConfig(),
         )
         with pytest.raises(KPIValidationError, match="amber_threshold_pct"):
             KPIService.create_kpi(payload, orguser)
@@ -228,6 +283,7 @@ class TestKPICRUD:
             metric_id=99999,
             direction="increase",
             time_grain="monthly",
+            extra_config=KPIExtraConfig(),
         )
         with pytest.raises(MetricNotFoundError):
             KPIService.create_kpi(payload, orguser)
@@ -275,13 +331,13 @@ class TestKPICRUD:
         kpi.delete()
 
     def test_update_kpi(self, orguser, org, sample_kpi, seed_db):
-        payload = KPIUpdate(name="Updated KPI", target_value=2000.0)
+        payload = KPIUpdate(name="Updated KPI", target_value=2000.0, extra_config=KPIExtraConfig())
         updated = KPIService.update_kpi(sample_kpi.id, org, orguser, payload)
         assert updated.name == "Updated KPI"
         assert updated.target_value == 2000.0
 
     def test_update_kpi_invalid_direction(self, orguser, org, sample_kpi, seed_db):
-        payload = KPIUpdate(direction="sideways")
+        payload = KPIUpdate(direction="sideways", extra_config=KPIExtraConfig())
         with pytest.raises(KPIValidationError):
             KPIService.update_kpi(sample_kpi.id, org, orguser, payload)
 


### PR DESCRIPTION
Main changes
- Ability to format kpis, similar to number chart
- Alerts built on KPIs will send the same formatted value
- KPI Wigets on dashboards and the frozen reports will show the formatted kpi card
- KPI annotation view will also show the formatted kpi value

Refactor
- Removed currency number format from all chart types because it was only prefixing the value & not actually doing any number format. Discussed this with product
- % percentage number format everywhere now does this : (0.85 ==> 85%) basically multiply by 100. 
- Commands on backend to handle created charts & reports for this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KPI cards and KPI-based report snapshots now preserve display customizations, including number formatting, prefixes, and suffixes.
  * Added broader number-format support for charts, including locale-aware, percentage, and compact formatting styles.

* **Bug Fixes**
  * KPI alert emails and messages now use the same formatted values shown in KPI cards.
  * Report snapshots now keep the formatting that was active when the snapshot was created, avoiding changes after later edits.
  * Legacy number-format settings are now migrated to the newer format for more consistent rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->