### PR TITLE
fix chart saving to metric library issue

### DIFF
--- a/ddpui/schemas/chart_schemas/config.py
+++ b/ddpui/schemas/chart_schemas/config.py
@@ -14,7 +14,6 @@ from ddpui.schemas.chart_schemas.customizations import (
     TableChartCustomizations,
 )
 
-
 # ── Shared sub-schemas (metrics, filters, sort, pagination, table dim) ──────
 
 
@@ -32,6 +31,7 @@ class ChartMetric(Schema):
     aggregation: Optional[ChartMetricAggregation] = None
     alias: Optional[str] = None
     column_expression: Optional[str] = None
+    saved_metric_id: Optional[int] = None
 
     @model_validator(mode="after")
     def check_aggregation_column_pair(self) -> "ChartMetric":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart configurations can now include an optional saved metric reference, improving support for reused or preconfigured metrics.
  * This expands the accepted metric payload without affecting existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->