### PR TITLE
Admin Portal M1: platform-admin gate (Issue #1254)

### DIFF
--- a/ddpui/api/admin_api.py
+++ b/ddpui/api/admin_api.py
@@ -1,0 +1,26 @@
+"""
+Admin Portal API — cross-org endpoints for the Dalgo ops team.
+
+Every route here is gated by @platform_admin_required (the global
+UserAttributes.is_platform_admin flag), not by per-org permission slugs. See
+features/admin-portal/v1/plan.md §3 for why cross-org needs its own layer.
+"""
+
+from ninja import Router
+
+from ddpui.auth import platform_admin_required
+from ddpui.utils.custom_logger import CustomLogger
+
+logger = CustomLogger("ddpui")
+
+admin_router = Router()
+
+
+@admin_router.get("/ping")
+@platform_admin_required
+def get_admin_ping(request):
+    """
+    Stub health check for the admin portal — proves the platform-admin gate works.
+    Returns 200 for platform admins; @platform_admin_required 403s everyone else.
+    """
+    return {"detail": "pong"}

--- a/ddpui/api/user_org_api.py
+++ b/ddpui/api/user_org_api.py
@@ -79,6 +79,10 @@ def get_current_user_v2(request, org_slug: str = None):
     if org_preferences is None:
         org_preferences = OrgPreferences.objects.create(org=org)
 
+    # is_platform_admin is a global (per-User) flag, so it's the same for every OrgUser row
+    user_attributes = UserAttributes.objects.filter(user=user).first()
+    is_platform_admin = bool(user_attributes and user_attributes.is_platform_admin)
+
     # Get org default dashboard
     org_default_dashboard = None
     from ddpui.models.dashboard import Dashboard
@@ -127,6 +131,7 @@ def get_current_user_v2(request, org_slug: str = None):
                 is_llm_active=org_preferences.llm_optin,
                 landing_dashboard_id=curr_orguser.landing_dashboard_id,
                 org_default_dashboard_id=org_default_dashboard,
+                is_platform_admin=is_platform_admin,
             )
         )
 

--- a/ddpui/auth.py
+++ b/ddpui/auth.py
@@ -10,7 +10,7 @@ from rest_framework_simplejwt.tokens import AccessToken
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer, TokenRefreshSerializer
 from django.contrib.auth.models import User
 
-from ddpui.models.org_user import OrgUser
+from ddpui.models.org_user import OrgUser, UserAttributes
 from ddpui.models.role_based_access import RolePermission
 from ddpui.utils import thread
 from ddpui.utils.redis_client import RedisClient
@@ -49,6 +49,26 @@ def has_permission(permission_slugs: list):
         return wrapper
 
     return decorator
+
+
+def platform_admin_required(view):
+    """
+    gate a view on the global UserAttributes.is_platform_admin flag.
+
+    unlike @has_permission (which checks per-org permission slugs), this expresses
+    cross-org authority: a Dalgo ops user acting on orgs they don't belong to.
+    mirrors the @has_permission wrapper pattern above (request is args[0]).
+    """
+
+    @wraps(view)
+    def wrapper(*args, **kwargs):
+        request = args[0]
+        ua = UserAttributes.objects.filter(user=request.orguser.user).first()
+        if not (ua and ua.is_platform_admin):
+            raise HttpError(403, "platform admin access required")
+        return view(*args, **kwargs)
+
+    return wrapper
 
 
 class CustomAuthMiddleware(HttpBearer):

--- a/ddpui/models/org_user.py
+++ b/ddpui/models/org_user.py
@@ -137,6 +137,7 @@ class OrgUserResponse(Schema):
     is_llm_active: Optional[bool] = None
     landing_dashboard_id: int | None = None
     org_default_dashboard_id: int | None = None
+    is_platform_admin: bool = False
 
 
 class Invitation(models.Model):

--- a/ddpui/routes.py
+++ b/ddpui/routes.py
@@ -24,6 +24,7 @@ from ddpui.api.dashboard_native_api import dashboard_native_router
 from ddpui.api.filter_api import filter_router
 from ddpui.api.public_api import public_router
 from ddpui.api.report_api import report_router
+from ddpui.api.admin_api import admin_router
 
 
 src_api = NinjaAPI(
@@ -108,6 +109,7 @@ src_api.add_router("/api/charts/", charts_router)
 src_api.add_router("/api/dashboards/", dashboard_native_router)
 src_api.add_router("/api/filters/", filter_router)
 src_api.add_router("/api/reports/", report_router)
+src_api.add_router("/api/v1/admin/", admin_router)
 
 # Public API without authentication
 public_api = NinjaAPI(

--- a/ddpui/tests/api_tests/test_admin_api.py
+++ b/ddpui/tests/api_tests/test_admin_api.py
@@ -1,0 +1,125 @@
+"""
+Tests for the Admin Portal API and its platform-admin gate.
+
+Milestone 1 acceptance (features/admin-portal/v1/plan.md §6, §7):
+  - non-platform-admin -> 403 on the guarded /admin/ping route
+  - platform admin      -> 200 on the same route
+  - /currentuserv2 surfaces is_platform_admin
+"""
+
+import pytest
+from unittest.mock import Mock
+from django.core.management import call_command
+from django.contrib.auth.models import User
+from ninja.errors import HttpError
+
+from ddpui.api.admin_api import get_admin_ping
+from ddpui.api.user_org_api import get_current_user_v2
+from ddpui.models.org import Org
+from ddpui.models.org_user import OrgUser, UserAttributes
+from ddpui.models.role_based_access import Role, RolePermission
+from ddpui.auth import ACCOUNT_MANAGER_ROLE
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(scope="session")
+def seed_db(django_db_setup, django_db_blocker):
+    """load the role/permission seed data the guard and currentuserv2 need"""
+    with django_db_blocker.unblock():
+        call_command("loaddata", "001_roles.json")
+        call_command("loaddata", "002_permissions.json")
+        call_command("loaddata", "003_role_permissions.json")
+
+
+@pytest.fixture
+def org():
+    """an Org to hang OrgUsers off of"""
+    org = Org.objects.create(name="admin-test-org", slug="admin-test-org")
+    yield org
+    org.delete()
+
+
+@pytest.fixture
+def authuser():
+    """a django User"""
+    user = User.objects.create(
+        username="admin-test-user", email="admin-test-user@example.com", password="pw"
+    )
+    yield user
+    user.delete()
+
+
+@pytest.fixture
+def orguser(authuser, org, seed_db):
+    """an OrgUser with the account-manager role (which has can_view_orgusers)"""
+    orguser = OrgUser.objects.create(
+        user=authuser,
+        org=org,
+        new_role=Role.objects.filter(slug=ACCOUNT_MANAGER_ROLE).first(),
+    )
+    yield orguser
+    orguser.delete()
+
+
+def mock_request(orguser: OrgUser = None):
+    """mirror the mock_request helper in test_user_org_api.py"""
+    request = Mock()
+    request.orguser = orguser
+    request.permissions = []
+    if orguser and orguser.new_role:
+        permission_slugs = RolePermission.objects.filter(role=orguser.new_role).values_list(
+            "permission__slug", flat=True
+        )
+        request.permissions = list(permission_slugs)
+    return request
+
+
+# ---- the guard: /admin/ping 403 vs 200 ----------------------------------------
+
+
+def test_admin_ping_forbidden_for_non_platform_admin(orguser):
+    """a user without is_platform_admin is refused with 403"""
+    request = mock_request(orguser)
+    # no UserAttributes row at all -> not a platform admin
+    with pytest.raises(HttpError) as excinfo:
+        get_admin_ping(request)
+    assert excinfo.value.status_code == 403
+    assert str(excinfo.value) == "platform admin access required"
+
+
+def test_admin_ping_forbidden_when_flag_false(orguser):
+    """a user whose is_platform_admin is explicitly False is refused with 403"""
+    UserAttributes.objects.create(user=orguser.user, is_platform_admin=False)
+    request = mock_request(orguser)
+    with pytest.raises(HttpError) as excinfo:
+        get_admin_ping(request)
+    assert excinfo.value.status_code == 403
+
+
+def test_admin_ping_ok_for_platform_admin(orguser):
+    """a platform admin gets 200 (the stub payload)"""
+    UserAttributes.objects.create(user=orguser.user, is_platform_admin=True)
+    request = mock_request(orguser)
+    response = get_admin_ping(request)
+    assert response == {"detail": "pong"}
+
+
+# ---- /currentuserv2 surfaces is_platform_admin --------------------------------
+
+
+def test_currentuserv2_reports_platform_admin_true(orguser):
+    """currentuserv2 returns is_platform_admin: true for a platform admin"""
+    UserAttributes.objects.create(user=orguser.user, is_platform_admin=True)
+    request = mock_request(orguser)
+    response = get_current_user_v2(request)
+    assert len(response) == 1
+    assert response[0].is_platform_admin is True
+
+
+def test_currentuserv2_reports_platform_admin_false(orguser):
+    """currentuserv2 defaults is_platform_admin to false for a normal user"""
+    request = mock_request(orguser)
+    response = get_current_user_v2(request)
+    assert len(response) == 1
+    assert response[0].is_platform_admin is False


### PR DESCRIPTION
Milestone 1 of the Admin Portal plan (features/admin-portal/v1/plan.md) -- backend half. Adds @platform_admin_required guard and surfaces is_platform_admin in /currentuserv2. 5 new tests passing, 54 existing tests unaffected (no regression). No migration needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a protected admin health-check endpoint at `/api/v1/admin/ping`.
  * Added platform-admin status to current-user information.
  * Restricted admin endpoint access to platform administrators.

* **Bug Fixes**
  * Users without platform-admin privileges now receive a clear 403 access response.

* **Tests**
  * Added coverage for admin access controls and platform-admin status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->