### PR TITLE
Add SupersetService.import_dashboard for provisioning standard dashboards

### DIFF
--- a/ddpui/services/superset_service.py
+++ b/ddpui/services/superset_service.py
@@ -410,6 +410,56 @@ class SupersetService:
             logger.error(f"Failed to create embedded UUID for dashboard {dashboard_id}: {str(e)}")
             return None
 
+    def import_dashboard(
+        self,
+        bundle_zip: bytes,
+        passwords: Optional[Dict[str, str]] = None,
+        overwrite: bool = True,
+    ) -> Dict[str, Any]:
+        """Import a dashboard export bundle (zip of yaml) into the org's Superset.
+
+        Used to provision Dalgo's standard dashboards (dalgo-dashboard-templates)
+        once the dbt_taf_metrics models have been built for the org. The caller
+        must rewrite the bundle's databases/*.yaml sqlalchemy_uri and
+        datasets/*.yaml schema to the org's warehouse before calling; `passwords`
+        maps each database yaml path inside the zip to its connection password,
+        since Superset never exports passwords.
+
+        Args:
+            bundle_zip: The dashboard export bundle as zip bytes
+            passwords: Mapping of database yaml path -> connection password
+            overwrite: Overwrite existing dashboards/charts/datasets with the
+                same UUIDs (makes re-provisioning idempotent)
+
+        Returns:
+            Superset's import response payload
+
+        Raises:
+            HttpError: On API failure
+        """
+        access_token = self.get_access_token()
+        csrf_token, session_cookie = self.get_csrf_token(access_token)
+
+        url = f"{self.org.viz_url.rstrip('/')}/api/v1/dashboard/import/"
+
+        response = self._make_request_with_retry(
+            "POST",
+            url,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "X-CSRFToken": csrf_token,
+                "Referer": f"{self.org.viz_url.rstrip('/')}",
+            },
+            files={"formData": ("dashboard_bundle.zip", bundle_zip, "application/zip")},
+            data={
+                "overwrite": json.dumps(overwrite),
+                "passwords": json.dumps(passwords or {}),
+            },
+            cookies={"session": session_cookie} if session_cookie else {},
+            timeout=120,
+        )
+        return response.json()
+
     def get_dashboard_by_id(self, dashboard_id: str) -> Dict[str, Any]:
         """Get single dashboard details.
 

--- a/ddpui/tests/services/test_superset_service.py
+++ b/ddpui/tests/services/test_superset_service.py
@@ -259,3 +259,52 @@ class TestSupersetService:
                 assert args[0] == cache_key
                 assert args[1] == thumbnail_data
                 assert args[2] == 3600  # Thumbnail cache TTL
+
+    def test_import_dashboard_success(self, superset_service, mock_redis):
+        """Test dashboard bundle import posts the zip with csrf + form fields."""
+        bundle_zip = b"fake-zip-bytes"
+
+        with patch.object(superset_service, "get_access_token", return_value="test-token"):
+            with patch.object(
+                superset_service,
+                "get_csrf_token",
+                return_value=("csrf-token", "session-cookie"),
+            ):
+                with patch.object(superset_service, "_make_request_with_retry") as mock_request:
+                    mock_response = Mock()
+                    mock_response.json.return_value = {"message": "OK"}
+                    mock_request.return_value = mock_response
+
+                    result = superset_service.import_dashboard(
+                        bundle_zip,
+                        passwords={"databases/warehouse.yaml": "secret"},
+                    )
+
+                    assert result == {"message": "OK"}
+                    args, kwargs = mock_request.call_args
+                    assert args[0] == "POST"
+                    assert args[1] == "https://superset.example.com/api/v1/dashboard/import/"
+                    assert kwargs["headers"]["X-CSRFToken"] == "csrf-token"
+                    assert kwargs["headers"]["Referer"] == "https://superset.example.com"
+                    assert kwargs["cookies"] == {"session": "session-cookie"}
+                    assert kwargs["files"]["formData"][1] == bundle_zip
+                    assert kwargs["data"]["overwrite"] == "true"
+                    assert json.loads(kwargs["data"]["passwords"]) == {
+                        "databases/warehouse.yaml": "secret"
+                    }
+
+    def test_import_dashboard_defaults(self, superset_service, mock_redis):
+        """Test import defaults: empty passwords, overwrite enabled."""
+        with patch.object(superset_service, "get_access_token", return_value="test-token"):
+            with patch.object(superset_service, "get_csrf_token", return_value=("csrf-token", "")):
+                with patch.object(superset_service, "_make_request_with_retry") as mock_request:
+                    mock_response = Mock()
+                    mock_response.json.return_value = {"message": "OK"}
+                    mock_request.return_value = mock_response
+
+                    superset_service.import_dashboard(b"zip")
+
+                    _, kwargs = mock_request.call_args
+                    assert kwargs["data"]["passwords"] == "{}"
+                    assert kwargs["data"]["overwrite"] == "true"
+                    assert kwargs["cookies"] == {}


### PR DESCRIPTION
## Why

Part of the standardized-metrics work ([design doc](https://github.com/DalgoT4D/dbt_taf_metrics)): orgs that enable the [`dbt_taf_metrics`](https://github.com/DalgoT4D/dbt_taf_metrics) package should get the canned **Survey Operations** / **Chat Engagement** dashboards ([DalgoT4D/dalgo-dashboard-templates](https://github.com/DalgoT4D/dalgo-dashboard-templates)) imported into their Superset automatically. `SupersetService` already has login/CSRF/retry plumbing but no import capability — this adds it.

## What

- `SupersetService.import_dashboard(bundle_zip, passwords=None, overwrite=True)` — wraps `POST /api/v1/dashboard/import/` with the service's existing `_make_request_with_retry`, CSRF token, Referer, and session-cookie handling. `overwrite=True` makes re-provisioning idempotent.
- The caller rewrites the bundle's `databases/*.yaml` sqlalchemy_uri and `datasets/*.yaml` schema to the org's warehouse before calling (reference implementation: `scripts/import_dashboards.py` in dalgo-dashboard-templates); `passwords` maps database yaml paths to connection passwords since Superset never exports them.
- Two unit tests in the existing `TestSupersetService` style; all 10 pass.

## Follow-up (separate PR)

The enablement flow (`POST /api/dalgo_metrics/enable/`: ensure package in org repo's packages.yml → write vars → dbt run → import bundles), per [docs/ddp_backend_integration.md](https://github.com/DalgoT4D/dalgo-dashboard-templates/blob/main/docs/ddp_backend_integration.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing Superset dashboard bundles from ZIP files.
  * Supports dashboard overwrite options and password mappings during import.

* **Bug Fixes**
  * Added automated coverage for successful imports and default import settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->