### PR TITLE
feat: add public endpoint to retrieve KPI chart data for dashboards

### DIFF
--- a/ddpui/api/public_api.py
+++ b/ddpui/api/public_api.py
@@ -1074,7 +1074,7 @@ def get_public_chart_data_preview_total_rows(request, token: str, chart_id: int)
 
 @public_router.get(
     "/dashboards/{token}/kpis/{kpi_id}/data/",
-    response={200: ChartDataResponse, 404: PublicErrorResponse},
+    response={200: ChartDataResponse, 400: PublicErrorResponse, 404: PublicErrorResponse},
 )
 def get_public_kpi_data(
     request,
@@ -1097,6 +1097,7 @@ def get_public_kpi_data(
             parsed_dashboard_filters = json.loads(dashboard_filters)
         except json.JSONDecodeError:
             logger.warning(f"Invalid dashboard_filters JSON for public KPI {kpi_id}: {dashboard_filters}")
+            return 400, PublicErrorResponse(error="Invalid dashboard_filters: must be valid JSON", is_valid=False)
 
     try:
         result = KPIService.get_kpi_data(

--- a/ddpui/api/public_api.py
+++ b/ddpui/api/public_api.py
@@ -1443,3 +1443,42 @@ def get_public_report_map_data(request, token: str):
     except Exception as e:
         logger.error(f"Public report map data error: {str(e)}")
         return 404, PublicErrorResponse(error="Map data unavailable", is_valid=False)
+
+
+@public_router.get(
+    "/reports/{token}/kpis/{kpi_id}/data/",
+    response={200: ChartDataResponse, 400: PublicErrorResponse, 404: PublicErrorResponse},
+)
+def get_public_report_kpi_data(
+    request,
+    token: str,
+    kpi_id: int,
+    dashboard_filters: Optional[str] = None,
+):
+    """Get KPI data for a public report snapshot — no authentication required."""
+    try:
+        snapshot = _get_public_report_snapshot(token, request=request)
+    except ReportSnapshot.DoesNotExist:
+        return 404, PublicErrorResponse(error="Report not found or no longer public", is_valid=False)
+
+    parsed_dashboard_filters = None
+    if dashboard_filters:
+        try:
+            parsed_dashboard_filters = json.loads(dashboard_filters)
+        except json.JSONDecodeError:
+            logger.warning(f"Invalid dashboard_filters JSON for public report KPI {kpi_id}: {dashboard_filters}")
+            return 400, PublicErrorResponse(error="Invalid dashboard_filters: must be valid JSON", is_valid=False)
+
+    try:
+        from ddpui.core.reports.report_service import ReportService
+        result = ReportService.get_report_kpi_data(
+            snapshot.id,
+            kpi_id,
+            snapshot.org,
+            dashboard_filters=parsed_dashboard_filters,
+        )
+    except Exception as e:
+        logger.error(f"Public report KPI data error for kpi {kpi_id}: {str(e)}")
+        return 404, PublicErrorResponse(error="KPI data unavailable", is_valid=False)
+
+    return ChartDataResponse(data=result["data"], echarts_config=result["echarts_config"])

--- a/ddpui/api/public_api.py
+++ b/ddpui/api/public_api.py
@@ -1089,15 +1089,21 @@ def get_public_kpi_data(
     try:
         dashboard = Dashboard.objects.get(public_share_token=token, is_public=True)
     except Dashboard.DoesNotExist:
-        return 404, PublicErrorResponse(error="Dashboard not found or no longer public", is_valid=False)
+        return 404, PublicErrorResponse(
+            error="Dashboard not found or no longer public", is_valid=False
+        )
 
     parsed_dashboard_filters = None
     if dashboard_filters:
         try:
             parsed_dashboard_filters = json.loads(dashboard_filters)
         except json.JSONDecodeError:
-            logger.warning(f"Invalid dashboard_filters JSON for public KPI {kpi_id}: {dashboard_filters}")
-            return 400, PublicErrorResponse(error="Invalid dashboard_filters: must be valid JSON", is_valid=False)
+            logger.warning(
+                f"Invalid dashboard_filters JSON for public KPI {kpi_id}: {dashboard_filters}"
+            )
+            return 400, PublicErrorResponse(
+                error="Invalid dashboard_filters: must be valid JSON", is_valid=False
+            )
 
     kpi_in_dashboard = any(
         comp.get("type") == "kpi" and comp.get("config", {}).get("kpiId") == kpi_id
@@ -1467,18 +1473,25 @@ def get_public_report_kpi_data(
     try:
         snapshot = _get_public_report_snapshot(token, request=request)
     except ReportSnapshot.DoesNotExist:
-        return 404, PublicErrorResponse(error="Report not found or no longer public", is_valid=False)
+        return 404, PublicErrorResponse(
+            error="Report not found or no longer public", is_valid=False
+        )
 
     parsed_dashboard_filters = None
     if dashboard_filters:
         try:
             parsed_dashboard_filters = json.loads(dashboard_filters)
         except json.JSONDecodeError:
-            logger.warning(f"Invalid dashboard_filters JSON for public report KPI {kpi_id}: {dashboard_filters}")
-            return 400, PublicErrorResponse(error="Invalid dashboard_filters: must be valid JSON", is_valid=False)
+            logger.warning(
+                f"Invalid dashboard_filters JSON for public report KPI {kpi_id}: {dashboard_filters}"
+            )
+            return 400, PublicErrorResponse(
+                error="Invalid dashboard_filters: must be valid JSON", is_valid=False
+            )
 
     try:
         from ddpui.core.reports.report_service import ReportService
+
         result = ReportService.get_report_kpi_data(
             snapshot.id,
             kpi_id,

--- a/ddpui/api/public_api.py
+++ b/ddpui/api/public_api.py
@@ -36,6 +36,8 @@ from ddpui.schemas.chart_schemas import ChartConfig, ChartDataResponse, ChartDat
 from ddpui.core.charts import charts_service
 from ddpui.core.charts.charts_service import get_warehouse_client, execute_query
 from ddpui.core.datainsights.query_builder import AggQueryBuilder
+from ddpui.core.kpi.kpi_service import KPIService
+from ddpui.core.kpi.exceptions import KPINotFoundError
 from sqlalchemy import func, column, distinct, cast, Float, Date
 
 logger = CustomLogger("ddpui")
@@ -1068,6 +1070,50 @@ def get_public_chart_data_preview_total_rows(request, token: str, chart_id: int)
     except Exception as e:
         logger.error(f"Public total rows error for chart {chart_id}: {str(e)}")
         return 404, PublicErrorResponse(error="Total rows unavailable", is_valid=False)
+
+
+@public_router.get(
+    "/dashboards/{token}/kpis/{kpi_id}/data/",
+    response={200: ChartDataResponse, 404: PublicErrorResponse},
+)
+def get_public_kpi_data(
+    request,
+    token: str,
+    kpi_id: int,
+    time_grain: Optional[str] = None,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    dashboard_filters: Optional[str] = None,
+):
+    """Get KPI chart data for a public dashboard — no authentication required."""
+    try:
+        dashboard = Dashboard.objects.get(public_share_token=token, is_public=True)
+    except Dashboard.DoesNotExist:
+        return 404, PublicErrorResponse(error="Dashboard not found or no longer public", is_valid=False)
+
+    parsed_dashboard_filters = None
+    if dashboard_filters:
+        try:
+            parsed_dashboard_filters = json.loads(dashboard_filters)
+        except json.JSONDecodeError:
+            logger.warning(f"Invalid dashboard_filters JSON for public KPI {kpi_id}: {dashboard_filters}")
+
+    try:
+        result = KPIService.get_kpi_data(
+            kpi_id,
+            dashboard.org,
+            time_grain_override=time_grain,
+            date_from=date_from,
+            date_to=date_to,
+            dashboard_filters=parsed_dashboard_filters,
+        )
+    except KPINotFoundError:
+        return 404, PublicErrorResponse(error="KPI not found", is_valid=False)
+    except Exception as e:
+        logger.error(f"Public KPI data error for kpi {kpi_id}: {str(e)}")
+        return 404, PublicErrorResponse(error="KPI data unavailable", is_valid=False)
+
+    return ChartDataResponse(data=result["data"], echarts_config=result["echarts_config"])
 
 
 # =============================================================================

--- a/ddpui/api/public_api.py
+++ b/ddpui/api/public_api.py
@@ -1099,6 +1099,14 @@ def get_public_kpi_data(
             logger.warning(f"Invalid dashboard_filters JSON for public KPI {kpi_id}: {dashboard_filters}")
             return 400, PublicErrorResponse(error="Invalid dashboard_filters: must be valid JSON", is_valid=False)
 
+    kpi_in_dashboard = any(
+        comp.get("type") == "kpi" and comp.get("config", {}).get("kpiId") == kpi_id
+        for tab in (dashboard.tabs or [])
+        for comp in (tab.get("components") or {}).values()
+    )
+    if not kpi_in_dashboard:
+        return 404, PublicErrorResponse(error="KPI not found on this dashboard", is_valid=False)
+
     try:
         result = KPIService.get_kpi_data(
             kpi_id,


### PR DESCRIPTION
## Summary
- Added `GET /api/v1/public/dashboards/{token}/kpis/{kpi_id}/data/` endpoint
- No authentication required — access is validated via the dashboard share token
- Reuses the same `KPIService.get_kpi_data()` logic as the private endpoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new public, unauthenticated API endpoints for fetching chart-ready KPI data from shared dashboard links and report snapshot links.
  * Dashboard endpoint supports optional time granularity, date ranges, and `dashboard_filters`; both endpoints return data plus chart configuration for visualization.
* **Bug Fixes**
  * Added consistent error handling: returns **400** for invalid `dashboard_filters` JSON and **404** when the requested KPI data (or snapshot) can’t be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->