### PR TITLE
fix: repair stale call sites left by the preprocess_airbyte_creds_for_dbt cleanup

### DIFF
--- a/ddpui/core/dbtfunctions.py
+++ b/ddpui/core/dbtfunctions.py
@@ -1,7 +1,4 @@
 import os
-from typing import Union
-
-from ddpui.ddpdbt.schema import DbtProjectParams
 
 # Fixed target label used inside profiles.yml. Matches proxy/prefect_flows_runner.py:DBT_TARGET
 # so backend-generated profiles.yml and runner-generated ones use the same key.

--- a/ddpui/ddpdbt/dbthelpers.py
+++ b/ddpui/ddpdbt/dbthelpers.py
@@ -151,9 +151,7 @@ def write_dbt_profiles_yml(org: Org) -> Path:
 
     dbt_project_params = DbtProjectManager.gather_dbt_project_params(org, org.dbt)
 
-    dbt_creds, wh_extras = preprocess_airbyte_creds_for_dbt(
-        warehouse, airbyte_creds, dbt_project_params
-    )
+    dbt_creds, wh_extras = preprocess_airbyte_creds_for_dbt(warehouse, airbyte_creds)
 
     dbt_project_filename = Path(dbt_project_params.project_dir) / "dbt_project.yml"
     if not dbt_project_filename.exists():

--- a/ddpui/management/commands/backfill_dbt_profile_secret_blocks.py
+++ b/ddpui/management/commands/backfill_dbt_profile_secret_blocks.py
@@ -4,10 +4,10 @@ runner-flow env key `dbt-profile-secret-block`.
 
 Per org:
   1. If org.dbt is not set, skip — the block is a dbt-lifecycle artifact.
-  2. Preprocess airbyte creds (map to dbt-postgres/dbt-bigquery fields, strip
-     ssl_mode/ssl) and upsert `dbt-profile-<slug>` Secret block via
-     create_or_update_dbt_profile_secret_blk. Sets
-     OrgDbt.dbt_profile_secret_block FK.
+  2. Upsert the `dbt-profile-<slug>` Secret block via
+     create_or_update_dbt_profile_secret_blk, passing the RAW airbyte creds —
+     that helper does the dbt-postgres/dbt-bigquery field mapping itself. Sets
+     both the OrgWarehouse and OrgDbt dbt_profile_secret_block FKs.
   3. For every OrgDataFlowv1 belonging to that org, fetch the deployment, find
      DBTCORE tasks, populate env with `dbt-profile-secret-block`. Idempotent —
      skips deployments already up to date.
@@ -17,10 +17,7 @@ CLI profile blocks are not touched.
 
 from django.core.management.base import BaseCommand
 
-from ddpui.core.dbtfunctions import preprocess_airbyte_creds_for_dbt
-from ddpui.core.orgdbt_manager import DbtProjectManager
 from ddpui.ddpdbt.dbthelpers import create_or_update_dbt_profile_secret_blk
-from ddpui.ddpdbt.schema import DbtProjectParams
 from ddpui.ddpprefect import DBTCORE
 from ddpui.ddpprefect.prefect_service import get_deployment, update_dataflow_v1
 from ddpui.ddpprefect.schema import PrefectDataFlowUpdateSchema3
@@ -64,20 +61,6 @@ class Command(BaseCommand):
                     skipped += 1
                     continue
 
-                dbt_project_params: DbtProjectParams | None = None
-                try:
-                    dbt_project_params = DbtProjectManager.gather_dbt_project_params(org, org.dbt)
-                except Exception as err:  # pylint: disable=broad-exception-caught
-                    # SSL cert path needs dbt_project_params; non-SSL orgs are fine
-                    print(
-                        f"  [warn] {org.slug}: gather_dbt_project_params failed ({err}); "
-                        "proceeding without it"
-                    )
-
-                dbt_creds, profile_extras = preprocess_airbyte_creds_for_dbt(
-                    warehouse, airbyte_creds, dbt_project_params
-                )
-
                 if options["dry_run"]:
                     print(
                         f"  [dry-run] {org.slug}: would upsert dbt-profile-{org.slug} "
@@ -86,9 +69,9 @@ class Command(BaseCommand):
                     ok += 1
                     continue
 
-                block = create_or_update_dbt_profile_secret_blk(
-                    org, warehouse, dbt_creds, profile_extras
-                )
+                # raw airbyte creds: create_or_update_dbt_profile_secret_blk runs
+                # preprocess_airbyte_creds_for_dbt itself, same as every other caller
+                block = create_or_update_dbt_profile_secret_blk(org, warehouse, airbyte_creds)
                 if block is None:
                     print(
                         f"  [fail] {org.slug}: create_or_update_dbt_profile_secret_blk returned None"

--- a/ddpui/tests/core/test_backfill_dbt_profile_secret_blocks.py
+++ b/ddpui/tests/core/test_backfill_dbt_profile_secret_blocks.py
@@ -1,0 +1,136 @@
+"""Tests for the backfill_dbt_profile_secret_blocks management command.
+
+These deliberately do NOT mock create_or_update_dbt_profile_secret_blk. A Mock
+accepts any signature, so mocking it hides exactly the class of bug this file
+exists to catch — the command called it with 4 positional args when it takes 3,
+and called preprocess_airbyte_creds_for_dbt with 3 when it takes 2. Only the
+external boundaries (secretsmanager, Prefect) are mocked, so the real call
+chain is exercised.
+"""
+
+import json
+import os
+from unittest.mock import Mock, patch
+
+import django
+import pytest
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ddpui.settings")
+os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+django.setup()
+
+from django.core.management import call_command
+
+from ddpui.models.org import Org, OrgDbt, OrgPrefectBlockv1, OrgWarehouse
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def org_with_warehouse():
+    """An org with dbt configured and a postgres warehouse, no dataflows."""
+    orgdbt = OrgDbt.objects.create(
+        gitrepo_url="repo", target_type="postgres", default_schema="intermediate"
+    )
+    org = Org.objects.create(name="backfill org", slug="backfill-org", dbt=orgdbt)
+    warehouse = OrgWarehouse.objects.create(org=org, wtype="postgres", name="wh")
+    return org, warehouse
+
+
+@patch("ddpui.ddpdbt.dbthelpers.prefect_service.upsert_secret_block")
+@patch(
+    "ddpui.management.commands.backfill_dbt_profile_secret_blocks."
+    "secretsmanager.retrieve_warehouse_credentials"
+)
+def test_backfill_writes_secret_block_for_org(
+    mock_retrieve: Mock, mock_upsert: Mock, org_with_warehouse
+):
+    """The non-dry-run path upserts the Secret block and wires the warehouse FK.
+
+    Regression guard: the command used to pass pre-processed creds plus an
+    extras dict (4 positional args) into a 3-arg helper, so every org failed
+    with a TypeError while --dry-run still reported success.
+    """
+    org, warehouse = org_with_warehouse
+    mock_retrieve.return_value = {
+        "username": "u",
+        "password": "pw",
+        "host": "h",
+        "port": 5432,
+        "database": "db",
+    }
+    mock_upsert.return_value = {
+        "block_id": "sec-id-1",
+        "block_name": "dbt-profile-backfill-org",
+    }
+
+    call_command("backfill_dbt_profile_secret_blocks", org="backfill-org")
+
+    # the deterministic block name reached Prefect
+    mock_upsert.assert_called_once()
+    assert mock_upsert.call_args.args[0].block_name == "dbt-profile-backfill-org"
+
+    # and the row is wired to the warehouse, which is what migration 0172 added
+    block = OrgPrefectBlockv1.objects.get(block_name="dbt-profile-backfill-org")
+    warehouse.refresh_from_db()
+    assert warehouse.dbt_profile_secret_block == block
+
+    org.dbt.refresh_from_db()
+    assert org.dbt.dbt_profile_secret_block == block
+
+
+@patch("ddpui.ddpdbt.dbthelpers.prefect_service.upsert_secret_block")
+@patch(
+    "ddpui.management.commands.backfill_dbt_profile_secret_blocks."
+    "secretsmanager.retrieve_warehouse_credentials"
+)
+def test_backfill_passes_raw_airbyte_creds_to_the_helper(
+    mock_retrieve: Mock, mock_upsert: Mock, org_with_warehouse
+):
+    """Creds are mapped once, by the helper — not pre-mapped by the command.
+
+    `username` must survive into the block value as dbt's `user`, and airbyte-only
+    keys must be stripped. Double-preprocessing or no preprocessing both break this.
+    """
+    _, _warehouse = org_with_warehouse
+    mock_retrieve.return_value = {
+        "username": "u",
+        "password": "pw",
+        "host": "h",
+        "port": 5432,
+        "database": "db",
+        "ssl_mode": {"mode": "require"},
+    }
+    mock_upsert.return_value = {
+        "block_id": "sec-id-2",
+        "block_name": "dbt-profile-backfill-org",
+    }
+
+    call_command("backfill_dbt_profile_secret_blocks", org="backfill-org")
+
+    block_value = json.loads(mock_upsert.call_args.args[0].secret)
+    assert block_value["wtype"] == "postgres"
+    assert block_value["default_schema"] == "intermediate"
+    # mapped by preprocess_airbyte_creds_for_dbt inside the helper
+    assert block_value["creds"]["user"] == "u"
+    assert block_value["creds"]["sslmode"] == "require"
+    assert "ssl_mode" not in block_value["creds"]
+
+
+@patch("ddpui.ddpdbt.dbthelpers.prefect_service.upsert_secret_block")
+@patch(
+    "ddpui.management.commands.backfill_dbt_profile_secret_blocks."
+    "secretsmanager.retrieve_warehouse_credentials"
+)
+def test_backfill_dry_run_writes_nothing(
+    mock_retrieve: Mock, mock_upsert: Mock, org_with_warehouse
+):
+    """--dry-run must not touch Prefect or the FK."""
+    _org, warehouse = org_with_warehouse
+    mock_retrieve.return_value = {"username": "u", "password": "pw"}
+
+    call_command("backfill_dbt_profile_secret_blocks", org="backfill-org", dry_run=True)
+
+    mock_upsert.assert_not_called()
+    warehouse.refresh_from_db()
+    assert warehouse.dbt_profile_secret_block is None


### PR DESCRIPTION
Commit e6f1bf1b narrowed preprocess_airbyte_creds_for_dbt from three
parameters to two, dropping the unused dbt_project_params. Two callers were
not updated, so both have been raising TypeError on main ever since:

  - ddpdbt/dbthelpers.py: write_dbt_profiles_yml — reached from
    airbytehelpers, dbt_service, elementary_service and celeryworkers.tasks,
    so this is a live path, not just tooling.
  - management/commands/backfill_dbt_profile_secret_blocks — fails per org
    with "takes 2 positional arguments but 3 were given".

The backfill command had a second, independent break: it pre-processed the
creds itself and then passed four positional args to
create_or_update_dbt_profile_secret_blk, which takes three. That helper calls
preprocess_airbyte_creds_for_dbt internally, exactly as its ten other callers
rely on, so the command's own preprocessing was wrong to exist. It now passes
the raw airbyte creds and lets the helper do the mapping once.

The command's --dry-run returns before the write, which is why it reported
ok=17 failed=0 while the real run failed for every org. That masked the bug
and made migration 0172's OrgWarehouse.dbt_profile_secret_block impossible to
backfill on any environment.

Also drops the now-unused Union and DbtProjectParams imports from
dbtfunctions.py and the dead gather_dbt_project_params block from the command,
and corrects the command's module docstring, which still described the
preprocessing it no longer does.

Adds ddpui/tests/core/test_backfill_dbt_profile_secret_blocks.py. The command
had no tests at all, which is how both breaks survived. The tests mock only
secretsmanager and Prefect, never create_or_update_dbt_profile_secret_blk — a
Mock accepts any signature, so mocking the helper would hide precisely this
class of bug. Verified by reverting the fix: the two write-path tests fail
with the original TypeErrors and the dry-run test still passes, reproducing
the masking.

pylint E1121 (too-many-function-args) is now 0 across ddpui/.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential handling when creating and updating data warehouse connection settings.
  * Ensured related connection references are updated consistently during backfills.
  * Preserved dry-run behavior so no changes are written during simulations.

* **Tests**
  * Added coverage for connection creation, credential preprocessing, reference updates, and dry-run safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->