### PR TITLE
feature/gsheets-managed-service-account

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -204,3 +204,14 @@ SCHEMA_CHANGE_DETECTION_SCHEDULE_HOUR=18
 SCHEMA_CHANGE_DETECTION_SCHEDULE_MINUTE=30
 # Number of days to retain audit logs. After this period, logs will be purged from the database.                 
 AUDIT_LOG_RETENTION_DAYS=365  
+
+####################################################################################################
+# MANAGED-SA bridge — TEMPORARY, delete once Google OAuth verification lands
+####################################################################################################
+
+# Absolute path to Dalgo's Google service-account key file. Set = the Google Sheets form drops
+# Google sign-in and offers two service-account options: this key (user shares their sheet with
+# its client_email as Viewer) or their own. Empty = the sign-in flow, unchanged.
+# A path, not inline JSON — python-dotenv mangles the newlines in private_key.
+# Adding this line needs a restart; changing the file's contents does not. Never commit the key.
+DALGO_MANAGED_GSHEETS_SERVICE_ACCOUNT_JSON_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,10 @@ platform-notifications/
 
 .vscode/
 .claude/worktrees/
+
+# Required for trial org creation
+.template_source_creds.json
+# MANAGED-SA bridge: Dalgo-managed Google service-account key. Never commit a private key.
+.dalgo_service_json_key.json
+
+

--- a/ddpui/api/airbyte_api.py
+++ b/ddpui/api/airbyte_api.py
@@ -117,7 +117,7 @@ def post_airbyte_source(request, payload: AirbyteSourceCreate):
 
     # MANAGED-SA bridge — no-op unless the key env var is set.
     payload.config = airbytehelpers.inject_managed_gsheets_credentials(
-        payload.sourceName, payload.config
+        payload.sourceDefName, payload.config
     )
 
     source = airbyte_service.create_source(
@@ -251,7 +251,7 @@ def put_airbyte_source(request, source_id: str, payload: AirbyteSourceUpdate):
 
     # MANAGED-SA bridge — no-op unless the key env var is set.
     payload.config = airbytehelpers.inject_managed_gsheets_credentials(
-        payload.sourceName, payload.config
+        payload.sourceDefName, payload.config
     )
 
     source = airbyte_service.update_source(
@@ -296,7 +296,7 @@ def post_airbyte_check_source(request, payload: AirbyteSourceCreate):
 
     # MANAGED-SA bridge — no-op unless the key env var is set.
     payload.config = airbytehelpers.inject_managed_gsheets_credentials(
-        payload.sourceName, payload.config
+        payload.sourceDefName, payload.config
     )
 
     response = airbyte_service.check_source_connection(orguser.org.airbyte_workspace_id, payload)
@@ -332,7 +332,7 @@ def post_airbyte_check_source_for_update(
 
     # MANAGED-SA bridge — no-op unless the key env var is set.
     payload.config = airbytehelpers.inject_managed_gsheets_credentials(
-        payload.sourceName, payload.config
+        payload.sourceDefName, payload.config
     )
 
     response = airbyte_service.check_source_connection_for_update(source_id, payload)

--- a/ddpui/api/airbyte_api.py
+++ b/ddpui/api/airbyte_api.py
@@ -1,5 +1,6 @@
 """Dalgo API for Airbyte"""
 
+import json
 import os
 from typing import List
 from ninja.errors import HttpError
@@ -34,7 +35,7 @@ from ddpui.models.org_user import OrgUser
 from ddpui.models.org import OrgType, ConnectionMeta
 from ddpui.models.llm import LogsSummarizationType, LlmSession, LlmSessionStatus
 from ddpui.ddpairbyte import airbytehelpers, deleteconnection
-from ddpui.core.oauth import google_oauth_service
+from ddpui.core.oauth import google_oauth_service, google_service_account
 from ddpui.utils.custom_logger import CustomLogger
 from ddpui.celeryworkers.tasks import (
     get_connection_catalog_task,
@@ -113,6 +114,11 @@ def post_airbyte_source(request, payload: AirbyteSourceCreate):
 
         payload.config = whitelisted_config
         logger.info("whitelisted the source config")
+
+    # MANAGED-SA bridge — no-op unless the key env var is set.
+    payload.config = airbytehelpers.inject_managed_gsheets_credentials(
+        payload.sourceName, payload.config
+    )
 
     source = airbyte_service.create_source(
         orguser.org.airbyte_workspace_id,
@@ -243,6 +249,11 @@ def put_airbyte_source(request, source_id: str, payload: AirbyteSourceUpdate):
         payload.config = whitelisted_config
         logger.info("whitelisted the source config for update")
 
+    # MANAGED-SA bridge — no-op unless the key env var is set.
+    payload.config = airbytehelpers.inject_managed_gsheets_credentials(
+        payload.sourceName, payload.config
+    )
+
     source = airbyte_service.update_source(
         source_id, payload.name, payload.config, payload.sourceDefId
     )
@@ -283,6 +294,11 @@ def post_airbyte_check_source(request, payload: AirbyteSourceCreate):
         payload.config = whitelisted_config
         logger.info("whitelisted the source config")
 
+    # MANAGED-SA bridge — no-op unless the key env var is set.
+    payload.config = airbytehelpers.inject_managed_gsheets_credentials(
+        payload.sourceName, payload.config
+    )
+
     response = airbyte_service.check_source_connection(orguser.org.airbyte_workspace_id, payload)
     return {
         "status": "succeeded" if response["jobInfo"]["succeeded"] else "failed",
@@ -314,11 +330,26 @@ def post_airbyte_check_source_for_update(
         payload.config = whitelisted_config
         logger.info("whitelisted the source config for update")
 
+    # MANAGED-SA bridge — no-op unless the key env var is set.
+    payload.config = airbytehelpers.inject_managed_gsheets_credentials(
+        payload.sourceName, payload.config
+    )
+
     response = airbyte_service.check_source_connection_for_update(source_id, payload)
     return {
         "status": "succeeded" if response["jobInfo"]["succeeded"] else "failed",
         "logs": response["jobInfo"]["logs"]["logLines"],
     }
+
+
+@airbyte_router.get("/sources/google_sheets/managed_service_account/")
+@has_permission(["can_view_sources"])
+def get_managed_google_service_account(request):  # pylint: disable=unused-argument
+    """MANAGED-SA bridge — the address users share their spreadsheet with, or null when the
+    deployment ships no key (which is how the UI knows the option is off). Only the client_email
+    is exposed; the key itself never leaves the backend."""
+    key = google_service_account.managed_service_account_json()
+    return {"email": json.loads(key).get("client_email") if key else None}
 
 
 @airbyte_router.get("/sources")

--- a/ddpui/core/oauth/google_service_account.py
+++ b/ddpui/core/oauth/google_service_account.py
@@ -1,0 +1,53 @@
+"""Dalgo-managed Google service-account credentials for the Airbyte Google Sheets connector.
+
+TEMPORARY BRIDGE — meant to be deleted.
+
+Google OAuth verification for the sensitive `spreadsheets.readonly` scope takes 3-4 weeks. A
+service account skips verification entirely (Google exempts apps accessing only their own data),
+at the cost of the user sharing each spreadsheet with the service account's email.
+
+Switched on by one env var pointing at the key file. Unset, it returns None and every call
+site falls through to the existing OAuth / bring-your-own-key behaviour. A path rather than
+inline JSON because python-dotenv mangles the escaped newlines in `private_key`.
+
+To retire: unset the env var (no deploy), then delete this module and every `MANAGED-SA` call
+site. `client_email` is the only part of the key that may leave the backend — the UI needs it to
+tell users which address to share with.
+"""
+
+import os
+
+from ddpui.utils.custom_logger import CustomLogger
+
+logger = CustomLogger("ddpui")
+
+# Path to the key file — the single switch for the whole bridge.
+MANAGED_SA_PATH_ENV = "DALGO_MANAGED_GSHEETS_SERVICE_ACCOUNT_JSON_PATH"
+
+# The connector spec's `credentials` oneOf, Service branch.
+CREDENTIALS_KEY = "credentials"
+AUTH_TYPE_KEY = "auth_type"
+SERVICE_AUTH_TYPE = "Service"
+SERVICE_INFO_KEY = "service_account_info"
+
+
+def managed_service_account_json() -> str | None:
+    """The service-account key JSON. None when the env var is unset or the file is unreadable or
+    empty — a broken key must degrade to "bridge off", never to a half-built credentials block.
+    Read per call, so swapping the file needs no restart."""
+    path = os.getenv(MANAGED_SA_PATH_ENV)
+    if not (path and path.strip()):
+        return None
+
+    try:
+        with open(path.strip(), "r", encoding="utf-8") as keyfile:
+            contents = keyfile.read().strip()
+    except OSError as err:
+        logger.error("managed google service-account key is unreadable at %s: %s", path, err)
+        return None
+
+    if not contents:
+        logger.error("managed google service-account key at %s is empty", path)
+        return None
+
+    return contents

--- a/ddpui/ddpairbyte/airbytehelpers.py
+++ b/ddpui/ddpairbyte/airbytehelpers.py
@@ -20,8 +20,9 @@ from django.forms.models import model_to_dict
 
 from ddpui.ddpairbyte import airbyte_service
 from ddpui.ddpairbyte.schema import AirbyteWorkspace
-from ddpui.core.oauth import google_oauth_service
+from ddpui.core.oauth import google_oauth_service, google_service_account
 from ddpui.core.oauth.google_oauth_provider import (
+    GSHEETS_SOURCE_NAME,
     get_connector,
     oauth_client_id,
     oauth_client_secret,
@@ -102,6 +103,35 @@ def _build_oauth_source_config(
         oauth_client_id(), oauth_client_secret(), refresh_token
     )
     return {**config, "credentials": credentials}
+
+
+def inject_managed_gsheets_credentials(source_name: str, config: dict) -> dict:
+    """MANAGED-SA bridge — fill in Dalgo's own Google service-account key for a Google Sheets
+    source that arrived without one. See `core/oauth/google_service_account.py` to remove it.
+
+    `source_name` is off the request payload, so this trusts the caller about the connector
+    type. Fine for an internal API; revisit if that changes."""
+    if source_name != GSHEETS_SOURCE_NAME:
+        return config
+
+    key = google_service_account.managed_service_account_json()
+    if key is None:
+        return config
+
+    # A pasted key is the bring-your-own-key option — only fill an empty slot. No Client
+    # (OAuth) guard needed: sign-in is unreleased, so no saved source carries one.
+    credentials = config.get(google_service_account.CREDENTIALS_KEY) or {}
+    if credentials.get(google_service_account.SERVICE_INFO_KEY):
+        return config
+
+    logger.info("using the dalgo-managed google service account for this google sheets source")
+    return {
+        **config,
+        google_service_account.CREDENTIALS_KEY: {
+            google_service_account.AUTH_TYPE_KEY: google_service_account.SERVICE_AUTH_TYPE,
+            google_service_account.SERVICE_INFO_KEY: key,
+        },
+    }
 
 
 def create_oauth_source(orguser: OrgUser, payload: SourceGoogleOAuthCreate) -> dict:

--- a/ddpui/ddpairbyte/airbytehelpers.py
+++ b/ddpui/ddpairbyte/airbytehelpers.py
@@ -105,13 +105,13 @@ def _build_oauth_source_config(
     return {**config, "credentials": credentials}
 
 
-def inject_managed_gsheets_credentials(source_name: str, config: dict) -> dict:
+def inject_managed_gsheets_credentials(source_def_name: str, config: dict) -> dict:
     """MANAGED-SA bridge — fill in Dalgo's own Google service-account key for a Google Sheets
     source that arrived without one. See `core/oauth/google_service_account.py` to remove it.
 
-    `source_name` is off the request payload, so this trusts the caller about the connector
+    `source_def_name` is off the request payload, so this trusts the caller about the connector
     type. Fine for an internal API; revisit if that changes."""
-    if source_name != GSHEETS_SOURCE_NAME:
+    if source_def_name != GSHEETS_SOURCE_NAME:
         return config
 
     key = google_service_account.managed_service_account_json()

--- a/ddpui/ddpairbyte/schema.py
+++ b/ddpui/ddpairbyte/schema.py
@@ -18,7 +18,7 @@ class AirbyteSourceCreate(Schema):
     config: dict
     # MANAGED-SA bridge: source-DEFINITION name (e.g. "Google Sheets"). Optional — absent
     # means no managed-key injection.
-    sourceName: str = None
+    sourceDefName: str = None
 
 
 class AirbyteSourceUpdate(Schema):
@@ -29,7 +29,7 @@ class AirbyteSourceUpdate(Schema):
     sourceDefId: str
     # MANAGED-SA bridge: source-DEFINITION name (e.g. "Google Sheets"). Optional — absent
     # means no managed-key injection.
-    sourceName: str = None
+    sourceDefName: str = None
 
 
 class AirbyteSourceUpdateCheckConnection(Schema):
@@ -39,7 +39,7 @@ class AirbyteSourceUpdateCheckConnection(Schema):
     config: dict
     # MANAGED-SA bridge: source-DEFINITION name (e.g. "Google Sheets"). Optional — absent
     # means no managed-key injection.
-    sourceName: str = None
+    sourceDefName: str = None
 
 
 class SourceGoogleOAuthConsentCreate(Schema):

--- a/ddpui/ddpairbyte/schema.py
+++ b/ddpui/ddpairbyte/schema.py
@@ -16,6 +16,9 @@ class AirbyteSourceCreate(Schema):
     name: str
     sourceDefId: str
     config: dict
+    # MANAGED-SA bridge: source-DEFINITION name (e.g. "Google Sheets"). Optional — absent
+    # means no managed-key injection.
+    sourceName: str = None
 
 
 class AirbyteSourceUpdate(Schema):
@@ -24,6 +27,9 @@ class AirbyteSourceUpdate(Schema):
     name: str
     config: dict
     sourceDefId: str
+    # MANAGED-SA bridge: source-DEFINITION name (e.g. "Google Sheets"). Optional — absent
+    # means no managed-key injection.
+    sourceName: str = None
 
 
 class AirbyteSourceUpdateCheckConnection(Schema):
@@ -31,6 +37,9 @@ class AirbyteSourceUpdateCheckConnection(Schema):
 
     name: str
     config: dict
+    # MANAGED-SA bridge: source-DEFINITION name (e.g. "Google Sheets"). Optional — absent
+    # means no managed-key injection.
+    sourceName: str = None
 
 
 class SourceGoogleOAuthConsentCreate(Schema):

--- a/ddpui/tests/core/test_google_service_account.py
+++ b/ddpui/tests/core/test_google_service_account.py
@@ -1,0 +1,143 @@
+"""MANAGED-SA bridge — tests for the Dalgo-managed Google service-account key.
+
+Delete alongside `ddpui/core/oauth/google_service_account.py` once Google OAuth verification
+lands and the bridge is retired.
+"""
+
+import json
+
+import pytest
+
+from ddpui.core.oauth import google_service_account
+from ddpui.core.oauth.google_oauth_provider import GSHEETS_SOURCE_NAME
+from ddpui.ddpairbyte import airbytehelpers
+
+# No django_db mark: every path here is pure config plumbing — env var in, credentials dict
+# out — with the one Airbyte lookup monkeypatched. Nothing touches the ORM.
+
+SERVICE_ACCOUNT_EMAIL = "dalgo-gsheets@dalgo-test.iam.gserviceaccount.com"
+
+
+def _key(**overrides) -> str:
+    payload = {
+        "type": "service_account",
+        "project_id": "dalgo-test",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----\n",
+        "client_email": SERVICE_ACCOUNT_EMAIL,
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+@pytest.fixture(name="managed_key")
+def fixture_managed_key(monkeypatch, tmp_path):
+    """Switch the bridge on with a usable key file."""
+    keyfile = tmp_path / "sa.json"
+    keyfile.write_text(_key(), encoding="utf-8")
+    monkeypatch.setenv(google_service_account.MANAGED_SA_PATH_ENV, str(keyfile))
+    return _key()
+
+
+@pytest.fixture(name="bridge_off")
+def fixture_bridge_off(monkeypatch):
+    """The default deployment: the env var is not set."""
+    monkeypatch.delenv(google_service_account.MANAGED_SA_PATH_ENV, raising=False)
+
+
+def _write_key(monkeypatch, tmp_path, contents: str) -> None:
+    """Point the bridge at a key file holding exactly `contents`."""
+    keyfile = tmp_path / "sa.json"
+    keyfile.write_text(contents, encoding="utf-8")
+    monkeypatch.setenv(google_service_account.MANAGED_SA_PATH_ENV, str(keyfile))
+
+
+# ---------------------------------------------------------------- availability
+
+
+def test_unavailable_when_no_env_var(bridge_off):  # pylint: disable=unused-argument
+    assert google_service_account.managed_service_account_json() is None
+
+
+def test_available_from_the_key_file(managed_key):  # pylint: disable=unused-argument
+    assert google_service_account.managed_service_account_json() == _key()
+
+
+def test_unavailable_when_the_key_file_is_empty(
+    monkeypatch, tmp_path, bridge_off
+):  # pylint: disable=unused-argument
+    """An empty placeholder file is a real state — the key gets created before it is filled."""
+    _write_key(monkeypatch, tmp_path, "")
+
+    assert google_service_account.managed_service_account_json() is None
+
+
+def test_unavailable_when_the_key_file_is_missing(
+    monkeypatch, tmp_path, bridge_off
+):  # pylint: disable=unused-argument
+    monkeypatch.setenv(
+        google_service_account.MANAGED_SA_PATH_ENV, str(tmp_path / "does-not-exist.json")
+    )
+
+    assert google_service_account.managed_service_account_json() is None
+
+
+# ------------------------------------------------------------------- injection
+#
+# The connector name comes off the request payload — there is no Airbyte lookup — so these
+# call the injector directly with the name the frontend would have sent.
+
+
+def test_injection_is_a_noop_while_the_bridge_is_off(bridge_off):  # pylint: disable=unused-argument
+    config = {"spreadsheet_id": "abc"}
+
+    assert airbytehelpers.inject_managed_gsheets_credentials(GSHEETS_SOURCE_NAME, config) == config
+
+
+def test_injection_fills_in_the_managed_key_for_google_sheets(managed_key):
+    result = airbytehelpers.inject_managed_gsheets_credentials(
+        GSHEETS_SOURCE_NAME, {"spreadsheet_id": "abc"}
+    )
+
+    assert result["spreadsheet_id"] == "abc"
+    assert result["credentials"] == {
+        "auth_type": "Service",
+        "service_account_info": managed_key,
+    }
+
+
+def test_injection_fills_in_an_empty_service_branch(managed_key):
+    """What the frontend actually sends on the managed path: the Service discriminator and
+    no key."""
+    result = airbytehelpers.inject_managed_gsheets_credentials(
+        GSHEETS_SOURCE_NAME, {"spreadsheet_id": "abc", "credentials": {"auth_type": "Service"}}
+    )
+
+    assert result["credentials"]["service_account_info"] == managed_key
+
+
+def test_injection_skips_other_connectors(managed_key):  # pylint: disable=unused-argument
+    """Every source type shares these endpoints, so a Postgres config must pass through
+    untouched even with the bridge on."""
+    config = {"host": "localhost"}
+
+    assert airbytehelpers.inject_managed_gsheets_credentials("Postgres", config) == config
+
+
+def test_injection_skips_a_source_with_no_name(managed_key):  # pylint: disable=unused-argument
+    """`sourceName` is optional on the payload schema — an older client that omits it gets the
+    old behaviour rather than a Google credentials block."""
+    config = {"host": "localhost"}
+
+    assert airbytehelpers.inject_managed_gsheets_credentials(None, config) == config
+
+
+def test_injection_never_trusts_a_client_supplied_key(
+    managed_key,
+):  # pylint: disable=unused-argument
+    """A pasted key is the bring-your-own-key path — it stays the user's, not Dalgo's."""
+    own_key = _key(client_email="someone-else@example.iam.gserviceaccount.com")
+    config = {"credentials": {"auth_type": "Service", "service_account_info": own_key}}
+
+    result = airbytehelpers.inject_managed_gsheets_credentials(GSHEETS_SOURCE_NAME, config)
+
+    assert result["credentials"]["service_account_info"] == own_key

--- a/ddpui/tests/core/test_google_service_account.py
+++ b/ddpui/tests/core/test_google_service_account.py
@@ -124,7 +124,7 @@ def test_injection_skips_other_connectors(managed_key):  # pylint: disable=unuse
 
 
 def test_injection_skips_a_source_with_no_name(managed_key):  # pylint: disable=unused-argument
-    """`sourceName` is optional on the payload schema — an older client that omits it gets the
+    """`sourceDefName` is optional on the payload schema — an older client that omits it gets the
     old behaviour rather than a Google credentials block."""
     config = {"host": "localhost"}
 

--- a/ddpui/tests/websockets/test_airbyte_consumer.py
+++ b/ddpui/tests/websockets/test_airbyte_consumer.py
@@ -203,6 +203,12 @@ def test_source_check_connection_demo_org(mock_airbyte_service, mock_airbyte_hel
         {"config": "whitelisted"},
         None,
     )
+    # The whole airbytehelpers module is patched, so the MANAGED-SA injector would otherwise hand
+    # back a MagicMock and overwrite the whitelisted config. Mirror what it really does for a
+    # non-Google-Sheets source: return the config untouched.
+    mock_airbyte_helpers.inject_managed_gsheets_credentials.side_effect = (
+        lambda source_name, config: config
+    )
     mock_airbyte_service.check_source_connection.return_value = {
         "jobInfo": {"succeeded": True, "logs": {"logLines": ["log1"]}}
     }

--- a/ddpui/tests/websockets/test_airbyte_consumer.py
+++ b/ddpui/tests/websockets/test_airbyte_consumer.py
@@ -207,7 +207,7 @@ def test_source_check_connection_demo_org(mock_airbyte_service, mock_airbyte_hel
     # back a MagicMock and overwrite the whitelisted config. Mirror what it really does for a
     # non-Google-Sheets source: return the config untouched.
     mock_airbyte_helpers.inject_managed_gsheets_credentials.side_effect = (
-        lambda source_name, config: config
+        lambda source_def_name, config: config
     )
     mock_airbyte_service.check_source_connection.return_value = {
         "jobInfo": {"succeeded": True, "logs": {"logLines": ["log1"]}}

--- a/ddpui/websockets/airbyte_consumer.py
+++ b/ddpui/websockets/airbyte_consumer.py
@@ -60,7 +60,7 @@ class SourceCheckConnectionConsumer(BaseConsumer):
         # MANAGED-SA bridge — the check must see the same credentials the save will use,
         # or it fails on a config that would actually work.
         payload.config = airbytehelpers.inject_managed_gsheets_credentials(
-            payload.sourceName, payload.config
+            payload.sourceDefName, payload.config
         )
 
         try:

--- a/ddpui/websockets/airbyte_consumer.py
+++ b/ddpui/websockets/airbyte_consumer.py
@@ -57,6 +57,12 @@ class SourceCheckConnectionConsumer(BaseConsumer):
             payload.config = whitelisted_config
             logger.info("whitelisted the source config")
 
+        # MANAGED-SA bridge — the check must see the same credentials the save will use,
+        # or it fails on a config that would actually work.
+        payload.config = airbytehelpers.inject_managed_gsheets_credentials(
+            payload.sourceName, payload.config
+        )
+
         try:
             if source_id:
                 response = airbyte_service.check_source_connection_for_update(source_id, payload)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added managed Google Sheets service-account support for source creation, updates, and connection checks.
  - Added a protected endpoint to view the configured service account’s email address without exposing private credentials.
  - Added environment configuration for the managed service-account key file.

- **Bug Fixes**
  - Preserved existing credentials and configurations when managed credentials are unavailable or already provided.

- **Tests**
  - Added coverage for credential availability, injection behavior, filtering, and disabled-bridge scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->