### PR TITLE
Prevent delayed sync from mutating trial canvases

### DIFF
--- a/ddpui/core/trial/clone_service.py
+++ b/ddpui/core/trial/clone_service.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.utils import timezone
 
-from ddpui.models.org import Org, OrgWarehouse, OrgFeatureFlag
+from ddpui.models.org import Org, OrgFeatureFlag, OrgWarehouse, TransformType
 from ddpui.core.trial.exceptions import TrialAccountExistsError, TrialCloneError
 from ddpui.core.trial.signup_record import record_trial_start
 from ddpui.core.trial.timing import step_timer
@@ -504,12 +504,13 @@ def _step_dbt(run: CloneRun) -> None:
             "setup_managed_git_workspace did not set the trial org's dbt workspace"
         )
 
-    # setup_managed_git_workspace hardcodes transform_type=GIT; mirror the TEMPLATE's value
-    # instead — a UI4T template must stay `ui` on the trial, otherwise the repo-to-canvas sync
-    # path (`sync_remote_dbtproject_to_canvas`, gated on GIT) becomes active and can re-parse
-    # the empty scaffold repo right over the copied CanvasNode/CanvasEdge rows.
-    if trial_dbt.transform_type != template_dbt.transform_type:
-        trial_dbt.transform_type = template_dbt.transform_type
+    # The copied CanvasNode/CanvasEdge graph is authoritative for a trial. Keep the managed Git
+    # repo and PAT for publishing and pipelines, but mark the transform workspace as UI-owned so
+    # opening the canvas cannot re-parse the repo and append stale/source-only nodes. The
+    # template may itself still be marked GIT for legacy reasons, so mirroring its value is not
+    # sufficient protection.
+    if trial_dbt.transform_type != TransformType.UI:
+        trial_dbt.transform_type = TransformType.UI
         trial_dbt.save(update_fields=["transform_type"])
 
     model_map = copy_dbt_dag(template_dbt, trial_dbt)

--- a/ddpui/tests/core/trial/test_clone_service.py
+++ b/ddpui/tests/core/trial/test_clone_service.py
@@ -1317,13 +1317,14 @@ def test_step_dbt_sets_up_workspace_and_copies_ui4t_rows_only(
     cli block), copies the template's UI4T DAG rows via copy_dbt_dag, then REGENERATES the trial
     repo's content by copying the template repo's models/ directory verbatim
     (copy_repo_models_from_template) so the trial user can create/edit/run models.
-    transform_type mirrors the template ('ui'), and the dbt system OrgTasks are still created."""
+    transform_type is forced to 'ui' so a delayed repo sync cannot mutate the copied canvas,
+    and the dbt system OrgTasks are still created."""
     template = Org.objects.create(name="tmpl-dbt", slug="tmpl-dbt")
     trial_org = Org.objects.create(name="Trial dbt", slug="trial-dbt")
 
+    # The production template is legacy-marked as github even though its authoritative graph was
+    # built in UI4T. The trial must not inherit that value.
     template_dbt = _make_orgdbt("tmpl-dbt")
-    template_dbt.transform_type = "ui"
-    template_dbt.save()
     template.dbt = template_dbt
     template.save()
     dest_model = OrgDbtModel.objects.create(
@@ -1345,7 +1346,7 @@ def test_step_dbt_sets_up_workspace_and_copies_ui4t_rows_only(
     # deliberately NO cli_profile_block — that field is legacy (only migration 0143 wrote it) and
     # setup_managed_git_workspace does not set it. _step_dbt must not depend on it.
     trial_dbt = _make_orgdbt("trial-dbt")
-    trial_dbt.transform_type = "github"  # setup hardcodes GIT; _step_dbt must mirror 'ui'
+    trial_dbt.transform_type = "github"  # setup hardcodes GIT; _step_dbt must force UI ownership
     trial_dbt.save()
 
     def fake_setup(org, project_name, default_schema):
@@ -1364,7 +1365,8 @@ def test_step_dbt_sets_up_workspace_and_copies_ui4t_rows_only(
         trial_org, project_name="dbtrepo", default_schema="default_schema"
     )
     trial_dbt.refresh_from_db()
-    assert trial_dbt.transform_type == "ui"  # mirrored from template, not left GIT
+    assert template_dbt.transform_type == "github"
+    assert trial_dbt.transform_type == "ui"
 
     # DAG rows copied; sql_path preserved (repo files copied to the same relative paths)
     trial_model = OrgDbtModel.objects.get(orgdbt=trial_dbt)


### PR DESCRIPTION
## Summary

- Keep cloned trial canvases UI4T-owned after managed Git setup.
- Preserve the managed repository and PAT used for publishing and pipelines.
- Add regression coverage for legacy templates marked as Git-managed.

## Validation

- `ddpui/tests/core/trial/test_clone_service.py`: 49 passed
- Targeted delayed-sync regression: passed