### PR TITLE
fixing alert firing on  cloned trial org

### DIFF
--- a/ddpui/core/trial/viz_clone.py
+++ b/ddpui/core/trial/viz_clone.py
@@ -40,7 +40,7 @@ from ddpui.utils.custom_logger import CustomLogger
 logger = CustomLogger("ddpui.core.trial.viz_clone")
 
 
-def _preserve_ordering_timestamps(instance, template_row) -> None:
+def _preserve_ordering_timestamps(instance, template_row, skip: tuple = ()) -> None:
     """Copy the template row's created_at/updated_at onto the freshly-created clone.
 
     The trial's list pages sort by `-updated_at` (charts, dashboards, metrics, kpis, alerts) or
@@ -49,11 +49,14 @@ def _preserve_ordering_timestamps(instance, template_row) -> None:
     tiebreak and the template's on-screen arrangement is lost. Writing the template's real
     timestamps via a queryset `.update()` (which bypasses auto_now/auto_now_add, unlike save())
     makes the trial list order match the template exactly. Fields absent on a model are skipped.
+
+    `skip` drops named fields from that copy, for models where a backdated timestamp is not
+    inert — see `_clone_alerts` and `scheduling.is_due`.
     """
     fields = {
         name: getattr(template_row, name)
         for name in ("created_at", "updated_at")
-        if hasattr(template_row, name)
+        if hasattr(template_row, name) and name not in skip
     }
     if fields:
         type(instance).objects.filter(pk=instance.pk).update(**fields)
@@ -333,7 +336,22 @@ def _clone_alerts(  # pylint: disable=unused-argument
         if new_a.is_active != a.is_active:
             Alert.objects.filter(pk=new_a.pk).update(is_active=a.is_active)
             new_a.is_active = a.is_active
-        _preserve_ordering_timestamps(new_a, a)
+
+        # Claim the tick that has already passed today. `scheduling.is_due` treats an alert as
+        # due when its most recent cron tick is later than `last_evaluated_at or created_at` —
+        # a clone starts with last_evaluated_at NULL, so without this stamp the trial's alerts
+        # all fire on the dispatcher's next 60s pass (a "0 9 * * *" alert cloned at 2pm emails
+        # the user immediately). Stamping now means the first email lands at the alert's next
+        # real scheduled tick.
+        claimed_at = timezone.now()
+        Alert.objects.filter(pk=new_a.pk).update(last_evaluated_at=claimed_at)
+        new_a.last_evaluated_at = claimed_at
+
+        # created_at is excluded: for every other model a backdated created_at only affects list
+        # ordering, but on Alert it is the is_due() floor that keeps a fresh alert from firing —
+        # copying the template's (months old) created_at would defeat the stamp above the moment
+        # last_evaluated_at is cleared or an evaluation resets it.
+        _preserve_ordering_timestamps(new_a, a, skip=("created_at",))
         count += 1
     return count
 

--- a/ddpui/tests/core/trial/test_viz_clone.py
+++ b/ddpui/tests/core/trial/test_viz_clone.py
@@ -1,6 +1,10 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
 import pytest
 from django.contrib.auth.models import User
 
+from ddpui.core.alerts import scheduling
 from ddpui.core.trial import viz_clone
 from ddpui.models.alert import Alert
 from ddpui.models.dashboard import Dashboard, DashboardFilter
@@ -427,7 +431,12 @@ def test_clone_alerts_remaps_metric_kpi_and_resets_delivery_state():
     assert new_alert.recipients == [{"type": "orguser", "orguser_id": trial_user.id}]
     assert new_alert.delivery_channels == ["email"]
     assert new_alert.slack_webhook_url is None
-    assert new_alert.last_evaluated_at is None
+    # the template's evaluation history is dropped, but the clone claims the current tick so it
+    # doesn't fire on the dispatcher's next pass — see
+    # test_clone_alerts_does_not_fire_before_next_scheduled_tick
+    assert new_alert.last_evaluated_at is not None
+    a.refresh_from_db()
+    assert new_alert.last_evaluated_at > a.last_evaluated_at
 
 
 def test_clone_alerts_preserves_inactive_template_alert():
@@ -469,6 +478,64 @@ def test_clone_alerts_preserves_inactive_template_alert():
 
     new_alert = Alert.objects.get(org=trial_org, name="InactiveAlert")
     assert new_alert.is_active is False
+
+
+def test_clone_alerts_does_not_fire_before_next_scheduled_tick():
+    """A cloned alert must wait for its next real cron tick.
+
+    `scheduling.is_due` floors "has this alert's last tick been consumed" at
+    `last_evaluated_at or created_at`. The clone copies the template row's timestamps for
+    list ordering, so the created_at floor is useless — without an explicit
+    `last_evaluated_at` stamp the trial's alerts all fire within 60s of signup.
+    """
+    template_org = _make_org("tmpl-alert-due")
+    trial_org = _make_org("trial-alert-due")
+    template_user = _make_orguser(template_org, "tmpl-alert-due@x.org")
+    trial_user = _make_orguser(trial_org, "trial-alert-due@x.org")
+
+    m = Metric.objects.create(
+        name="Metric1",
+        schema_name="analytics",
+        table_name="t",
+        column="id",
+        aggregation="count",
+        org=template_org,
+        created_by=template_user,
+        last_modified_by=template_user,
+    )
+    a = Alert.objects.create(
+        org=template_org,
+        name="DailyNine",
+        alert_type="metric_threshold",
+        metric=m,
+        condition={"operator": "lt", "value": 10},
+        schedule_cron="0 9 * * *",
+        delivery_channels=["email"],
+        message_template="{{value}}",
+        recipients=[{"type": "external", "email": "tmpl-owner@x.org"}],
+        created_by=template_user,
+        last_modified_by=template_user,
+    )
+    # template alert is old — this is what the clone copies onto created_at
+    old = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    Alert.objects.filter(pk=a.pk).update(created_at=old, updated_at=old)
+    a.refresh_from_db()
+
+    metric_map = viz_clone._clone_metrics(template_org, trial_org, trial_user)
+
+    # clone at 14:00 UTC — today's 09:00 tick is already in the past
+    cloned_at = datetime(2026, 8, 18, 14, 0, tzinfo=timezone.utc)
+    with patch("ddpui.core.trial.viz_clone.timezone.now", return_value=cloned_at):
+        viz_clone._clone_alerts(template_org, trial_org, trial_user, metric_map, {})
+
+    new_alert = Alert.objects.get(org=trial_org, name="DailyNine")
+
+    # the dispatcher's very next 60s tick must not pick it up
+    assert scheduling.is_due(new_alert, cloned_at + timedelta(seconds=60)) is False
+    # nor at any point before tomorrow's 09:00
+    assert scheduling.is_due(new_alert, datetime(2026, 8, 19, 8, 59, tzinfo=timezone.utc)) is False
+    # but it does fire at its real scheduled time
+    assert scheduling.is_due(new_alert, datetime(2026, 8, 19, 9, 1, tzinfo=timezone.utc)) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`last_eval = alert.last_evaluated_at or alert.created_at`

last evaluated is null for new trial org. so fallback to created_at. We were copying the created_at of the template org. 
Now last_evaluated_at = current time. So it will fire on its usual time. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert cloning to preserve scheduling behavior and prevent cloned alerts from triggering immediately.
  * Ensured cloned alerts receive a current evaluation timestamp while maintaining update ordering.
  * Fixed daily alerts so they remain inactive until their next scheduled run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->