### PR TITLE
feat(public-api): send org_slug on public dashboard and report views

### DIFF
--- a/ddpui/api/public_api.py
+++ b/ddpui/api/public_api.py
@@ -50,6 +50,10 @@ class PublicDashboardResponse(DashboardResponse):
     """Extended dashboard response for public access with additional public fields"""
 
     org_name: str
+    # Stable org identifier (never renamed, unlike org_name). Public views are
+    # anonymous, so this is the only way analytics can attribute a public view
+    # to an org — it must match the slug used everywhere else.
+    org_slug: str
     org_logo_url: Optional[str] = None
     is_valid: bool = True
 
@@ -114,6 +118,7 @@ def get_public_dashboard(request, token: str):
         public_response_data = {
             **dashboard_data,
             "org_name": dashboard.org.name,
+            "org_slug": dashboard.org.slug,
             "org_logo_url": dashboard.org.logo_url,
             "is_valid": True,
             # Remove sensitive fields for public access
@@ -1189,6 +1194,10 @@ def get_public_report(request, token: str):
         return {
             **view_data,
             "org_name": snapshot.org.name,
+            # Stable org identifier (never renamed, unlike org_name). A public view is
+            # anonymous, so this is the only way analytics can attribute the read to an
+            # org — same reasoning and same key as PublicDashboardResponse.org_slug.
+            "org_slug": snapshot.org.slug,
             "org_logo_url": snapshot.org.logo_url,
             "is_valid": True,
         }

--- a/ddpui/api/public_api.py
+++ b/ddpui/api/public_api.py
@@ -50,9 +50,6 @@ class PublicDashboardResponse(DashboardResponse):
     """Extended dashboard response for public access with additional public fields"""
 
     org_name: str
-    # Stable org identifier (never renamed, unlike org_name). Public views are
-    # anonymous, so this is the only way analytics can attribute a public view
-    # to an org — it must match the slug used everywhere else.
     org_slug: str
     org_logo_url: Optional[str] = None
     is_valid: bool = True
@@ -1194,9 +1191,6 @@ def get_public_report(request, token: str):
         return {
             **view_data,
             "org_name": snapshot.org.name,
-            # Stable org identifier (never renamed, unlike org_name). A public view is
-            # anonymous, so this is the only way analytics can attribute the read to an
-            # org — same reasoning and same key as PublicDashboardResponse.org_slug.
             "org_slug": snapshot.org.slug,
             "org_logo_url": snapshot.org.logo_url,
             "is_valid": True,

--- a/ddpui/tests/api_tests/test_public_dashboard_api.py
+++ b/ddpui/tests/api_tests/test_public_dashboard_api.py
@@ -1,0 +1,150 @@
+"""Tests for the public dashboard API endpoint (no authentication)
+
+Tests:
+1. get_public_dashboard — valid token returns org identity (org_slug + org_name),
+   increments the access count, and rejects invalid / non-public tokens
+"""
+
+import os
+import django
+import pytest
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ddpui.settings")
+os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+django.setup()
+
+from django.contrib.auth.models import User
+from django.test import RequestFactory
+from ddpui.models.org import Org
+from ddpui.models.org_user import OrgUser
+from ddpui.models.role_based_access import Role
+from ddpui.models.dashboard import Dashboard
+from ddpui.auth import ACCOUNT_MANAGER_ROLE
+from ddpui.api.public_api import get_public_dashboard
+from ddpui.tests.api_tests.test_user_org_api import seed_db
+
+pytestmark = pytest.mark.django_db
+
+rf = RequestFactory()
+
+
+def _make_public_request():
+    """A public endpoint request — no auth, but the handler reads IP / user agent"""
+    request = rf.get("/api/v1/public/dashboards/")
+    request.META["REMOTE_ADDR"] = "127.0.0.1"
+    request.META["HTTP_USER_AGENT"] = "TestAgent"
+    return request
+
+
+@pytest.fixture
+def authuser():
+    user = User.objects.create(
+        username="pubdashuser", email="pubdashuser@test.com", password="testpassword"
+    )
+    yield user
+    user.delete()
+
+
+@pytest.fixture
+def org():
+    org = Org.objects.create(
+        name="Public Dashboard Test Org",
+        slug="pub-dash-test-org",
+        airbyte_workspace_id="workspace-id",
+    )
+    yield org
+    org.delete()
+
+
+@pytest.fixture
+def orguser(authuser, org):
+    orguser = OrgUser.objects.create(
+        user=authuser,
+        org=org,
+        new_role=Role.objects.filter(slug=ACCOUNT_MANAGER_ROLE).first(),
+    )
+    yield orguser
+    orguser.delete()
+
+
+def _create_dashboard(orguser, org, **kwargs):
+    dashboard = Dashboard.objects.create(
+        title="Test Dashboard",
+        description="Test",
+        dashboard_type="native",
+        grid_columns=12,
+        tabs=[
+            {
+                "id": "tab-1",
+                "title": "Tab 1",
+                "layout_config": [],
+                "components": {},
+            }
+        ],
+        created_by=orguser,
+        org=org,
+        **kwargs,
+    )
+    return dashboard
+
+
+@pytest.fixture
+def public_dashboard(orguser, org):
+    dashboard = _create_dashboard(orguser, org, is_public=True, public_share_token="pub-dash-token")
+    yield dashboard
+    try:
+        dashboard.refresh_from_db()
+        dashboard.delete()
+    except Dashboard.DoesNotExist:
+        pass
+
+
+@pytest.fixture
+def private_dashboard(orguser, org):
+    dashboard = _create_dashboard(orguser, org, is_public=False, public_share_token="priv-token")
+    yield dashboard
+    try:
+        dashboard.refresh_from_db()
+        dashboard.delete()
+    except Dashboard.DoesNotExist:
+        pass
+
+
+class TestGetPublicDashboard:
+    """Tests for the get_public_dashboard endpoint"""
+
+    def test_valid_token_returns_org_identity(self, public_dashboard, seed_db):
+        """org_slug rides along with org_name — anonymous public views have no
+        person or group, so the slug is the only org attribution available."""
+        request = _make_public_request()
+        response = get_public_dashboard(request, public_dashboard.public_share_token)
+
+        assert response.is_valid is True
+        assert response.org_slug == "pub-dash-test-org"
+        assert response.org_name == "Public Dashboard Test Org"
+        assert response.id == public_dashboard.id
+
+    def test_valid_token_increments_access_count(self, public_dashboard, seed_db):
+        request = _make_public_request()
+        get_public_dashboard(request, public_dashboard.public_share_token)
+        get_public_dashboard(request, public_dashboard.public_share_token)
+
+        public_dashboard.refresh_from_db()
+        assert public_dashboard.public_access_count == 2
+        assert public_dashboard.last_public_accessed is not None
+
+    def test_invalid_token(self, seed_db):
+        request = _make_public_request()
+        status, response = get_public_dashboard(request, "nonexistent-token")
+
+        assert status == 404
+        assert response.is_valid is False
+        assert "not found" in response.error.lower()
+
+    def test_private_dashboard_not_accessible(self, private_dashboard, seed_db):
+        """A dashboard with a token but is_public=False stays inaccessible"""
+        request = _make_public_request()
+        status, response = get_public_dashboard(request, private_dashboard.public_share_token)
+
+        assert status == 404
+        assert response.is_valid is False

--- a/ddpui/tests/api_tests/test_public_report_api.py
+++ b/ddpui/tests/api_tests/test_public_report_api.py
@@ -245,6 +245,19 @@ class TestGetPublicReport:
         assert "report_metadata" in response
         assert response["report_metadata"]["title"] == "Public Report"
 
+    @patch("ddpui.core.reports.report_service.ReportService._inject_period_into_chart_configs")
+    def test_returns_org_slug(self, mock_inject, public_snapshot, seed_db):
+        """The response carries the org's stable slug, not just its display name.
+
+        A public view is anonymous — no user, no org group — so the payload is the only
+        way analytics can attribute the read to an org. org_name can be renamed and is
+        not a stable key; the slug is. Matches PublicDashboardResponse.
+        """
+        request = _make_public_request()
+        response = get_public_report(request, public_snapshot.public_share_token)
+
+        assert response["org_slug"] == "pub-rpt-test-org"
+
     def test_invalid_token(self, seed_db):
         """Invalid token returns 404"""
         request = _make_public_request()


### PR DESCRIPTION
A public view is anonymous — no authenticated user and no organization group — so whatever the payload carries is the only way analytics can attribute the read to an org. org_name was the sole org field, and it is a display name: it can be renamed, which breaks any historical join, and it does not match the slug used as the org key everywhere else, so public reads could not be lined up with the rest of an org's numbers.

Both public endpoints now return org_slug alongside org_name — the dashboard via a declared field on PublicDashboardResponse, the report in its response dict (that endpoint is typed as a bare dict). Both already select_related the org, so neither adds a query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public dashboard and report responses now include the organization’s stable identifier.
* **Bug Fixes**
  * Improved validation for public access tokens and private dashboard access.
  * Public dashboard views now correctly record access counts.
* **Tests**
  * Added coverage for organization identification, dashboard visibility, token validation, and access tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->